### PR TITLE
actions: image-partition: fix fstab entry generation for 'fat32'

### DIFF
--- a/actions/image_partition_action.go
+++ b/actions/image_partition_action.go
@@ -51,8 +51,13 @@ func (i *ImagePartitionAction) generateFSTab(context *debos.DebosContext) error 
 		if m.part.FSUUID == "" {
 			return fmt.Errorf("Missing fs UUID for partition %s!?!", m.part.Name)
 		}
+		fs := m.part.FS
+		switch m.part.FS {
+		case "fat32":
+			fs = "vfat"
+		}
 		context.ImageFSTab.WriteString(fmt.Sprintf("UUID=%s\t%s\t%s\t%s\t0\t0\n",
-			m.part.FSUUID, m.Mountpoint, m.part.FS,
+			m.part.FSUUID, m.Mountpoint, fs,
 			strings.Join(options, ",")))
 	}
 


### PR DESCRIPTION
FAT partitions can't be mounted with 'fat32' partition type.
'vfat' partition type must be used for 'fat32' entries for correct mount.

Signed-off-by: Denis Pynkin <denis.pynkin@collabora.com>