### PR TITLE
actions: yaml typo fix

### DIFF
--- a/actions/debootstrap_action.go
+++ b/actions/debootstrap_action.go
@@ -15,7 +15,7 @@ type DebootstrapAction struct {
 	Suite          string
 	Mirror         string
 	Variant        string
-	KeyringPackage string `yaml: keyring-package`
+	KeyringPackage string `yaml:"keyring-package"`
 	Components     []string
 }
 

--- a/actions/filesystem_deploy_action.go
+++ b/actions/filesystem_deploy_action.go
@@ -15,8 +15,8 @@ import (
 
 type FilesystemDeployAction struct {
 	debos.BaseAction         `yaml:",inline"`
-	SetupFSTab         bool `yaml:setup-fstab`
-	SetupKernelCmdline bool `yaml:setup-kernel-cmdline`
+	SetupFSTab         bool `yaml:"setup-fstab"`
+	SetupKernelCmdline bool `yaml:"setup-kernel-cmdline"`
 }
 
 func NewFilesystemDeployAction() *FilesystemDeployAction {

--- a/actions/ostree_deploy_action.go
+++ b/actions/ostree_deploy_action.go
@@ -17,8 +17,8 @@ type OstreeDeployAction struct {
 	RemoteRepository    string "remote_repository"
 	Branch              string
 	Os                  string
-	SetupFSTab          bool `yaml:setup-fstab`
-	SetupKernelCmdline  bool `yaml:setup-kernel-cmdline`
+	SetupFSTab          bool   `yaml:"setup-fstab"`
+	SetupKernelCmdline  bool   `yaml:"setup-kernel-cmdline"`
 	AppendKernelCmdline string
 }
 


### PR DESCRIPTION
Some of properties can't be recognized by YAML parser due missed quotes.

Signed-off-by: Denis Pynkin <denis.pynkin@collabora.com>