### PR TITLE
 actions: add description of actions 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,51 @@
+
+# Created by https://www.gitignore.io/api/vim,linux,go
+
+### Go ###
+# Binaries for programs and plugins
+*.exe
+*.dll
+*.so
+*.dylib
+
+# Test binary, build with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+# Project-local glide cache, RE: https://github.com/Masterminds/glide/issues/736
+.glide/
+
+# Golang project vendor packages which should be ignored
+vendor/
+
+### Linux ###
+*~
+
+# temporary files which can be created if a process still has a handle open of a deleted file
+.fuse_hidden*
+
+# KDE directory preferences
+.directory
+
+# Linux trash folder which might appear on any partition or disk
+.Trash-*
+
+# .nfs files are created when an open file is removed but is still being accessed
+.nfs*
+
+### Vim ###
+# swap
+[._]*.s[a-v][a-z]
+[._]*.sw[a-p]
+[._]s[a-v][a-z]
+[._]sw[a-p]
+# session
+Session.vim
+# temporary
+.netrwhist
+# auto-generated tag files
+tags
+
+# End of https://www.gitignore.io/api/vim,linux,go

--- a/actions/actions_doc.go
+++ b/actions/actions_doc.go
@@ -1,0 +1,6 @@
+// Copyright 2017, Collabora Ltd.
+
+/*
+Package 'actions' implements 'debos' modules used for OS creation.
+*/
+package actions

--- a/actions/apt_action.go
+++ b/actions/apt_action.go
@@ -1,3 +1,23 @@
+/*
+Apt Action
+
+Install packages and their dependencies to the target rootfs with 'apt'.
+
+Yaml syntax:
+ - action: apt
+   recommends: bool
+   packages:
+     - package1
+     - package2
+
+Mandatory properties:
+
+- packages -- list of packages to install
+
+Optional properties:
+
+- recommends -- boolean indicating if suggested packages will be installed
+*/
 package actions
 
 import (
@@ -6,8 +26,8 @@ import (
 
 type AptAction struct {
 	debos.BaseAction `yaml:",inline"`
-	Recommends bool
-	Packages   []string
+	Recommends       bool
+	Packages         []string
 }
 
 func (apt *AptAction) Run(context *debos.DebosContext) error {

--- a/actions/debootstrap_action.go
+++ b/actions/debootstrap_action.go
@@ -1,3 +1,32 @@
+/*
+Debootstrap Action
+
+Construct the target rootfs with debootstrap tool.
+
+Yaml syntax:
+ - action: debootstrap
+   mirror: URL
+   suite: "name"
+   components: <list of components>
+   variant: "name"
+   keyring-package:
+
+Mandatory properties:
+
+- suite -- release code name or symbolic name (e.g. "stable")
+
+Optional properties:
+
+- mirror -- URL with Debian-compatible repository
+
+- variant -- name of the bootstrap script variant to use
+
+- components -- list of components to use for packages selection.
+Example:
+ components: [ main, contrib ]
+
+- keyring-package -- keyring for packages validation. Currently ignored.
+*/
 package actions
 
 import (
@@ -11,13 +40,13 @@ import (
 )
 
 type DebootstrapAction struct {
-	debos.BaseAction     `yaml:",inline"`
-	Suite          string
-	Mirror         string
-	Variant        string
-	KeyringPackage string `yaml:"keyring-package"`
-	Components     []string
-	MergedUsr      bool `yaml:"merged-usr"`
+	debos.BaseAction `yaml:",inline"`
+	Suite            string
+	Mirror           string
+	Variant          string
+	KeyringPackage   string `yaml:"keyring-package"`
+	Components       []string
+	MergedUsr        bool `yaml:"merged-usr"`
 }
 
 func NewDebootstrapAction() *DebootstrapAction {
@@ -25,6 +54,7 @@ func NewDebootstrapAction() *DebootstrapAction {
 	// Use filesystem with merged '/usr' by default
 	d.MergedUsr = true
 	return &d
+
 }
 
 func (d *DebootstrapAction) RunSecondStage(context debos.DebosContext) error {

--- a/actions/debootstrap_action.go
+++ b/actions/debootstrap_action.go
@@ -17,6 +17,14 @@ type DebootstrapAction struct {
 	Variant        string
 	KeyringPackage string `yaml:"keyring-package"`
 	Components     []string
+	MergedUsr      bool `yaml:"merged-usr"`
+}
+
+func NewDebootstrapAction() *DebootstrapAction {
+	d := DebootstrapAction{}
+	// Use filesystem with merged '/usr' by default
+	d.MergedUsr = true
+	return &d
 }
 
 func (d *DebootstrapAction) RunSecondStage(context debos.DebosContext) error {
@@ -39,8 +47,11 @@ func (d *DebootstrapAction) RunSecondStage(context debos.DebosContext) error {
 
 func (d *DebootstrapAction) Run(context *debos.DebosContext) error {
 	d.LogStart()
-	cmdline := []string{"debootstrap", "--no-check-gpg",
-		"--merged-usr"}
+	cmdline := []string{"debootstrap", "--no-check-gpg"}
+
+	if d.MergedUsr {
+		cmdline = append(cmdline, "--merged-usr")
+	}
 
 	if d.KeyringPackage != "" {
 		cmdline = append(cmdline, fmt.Sprintf("--keyring=%s", d.KeyringPackage))

--- a/actions/download_action.go
+++ b/actions/download_action.go
@@ -1,3 +1,35 @@
+/*
+Download Action
+
+Download a single file from Internet and unpack it in place if needed.
+
+Yaml syntax:
+ - action: download
+   url: http://example.domain/path/filename.ext
+   name: firmware
+   filename: output_name
+   unpack: bool
+   compression: gz
+
+Mandatory properties:
+
+- url -- URL to an object for download
+
+- name -- string which allow to use downloaded object in other actions
+via 'origin' property. If 'unpack' property is set to 'true' name will
+refer to temporary directory with extracted content.
+
+Optional properties:
+
+- filename -- use this property as the name for saved file. Useful if URL does not
+contain file name in path, for example it is possible to download files from URLs without path part.
+
+- unpack -- hint for action to extract all files from downloaded archive.
+See the 'Unpack' action for more information.
+
+- compression -- optional hint for unpack allowing to use proper compression method.
+See the 'Unpack' action for more information.
+*/
 package actions
 
 import (

--- a/actions/filesystem_deploy_action.go
+++ b/actions/filesystem_deploy_action.go
@@ -1,3 +1,22 @@
+/*
+FilesystemDeploy Action
+
+Deploy prepared root filesystem to output image. This action requires
+'image-partition' action to be executed before it.
+
+Yaml syntax:
+ - action: filesystem-deploy
+   setup-fstab: bool
+   setup-kernel-cmdline: bool
+
+Optional properties:
+
+- setup-fstab -- generate '/etc/fstab' file according to information provided
+by 'image-partition' action. By default is 'true'.
+
+- setup-kernel-cmdline -- add location of root partition to '/etc/kernel/cmdline'
+file on target image. By default is 'true'.
+*/
 package actions
 
 import (
@@ -14,7 +33,7 @@ import (
 )
 
 type FilesystemDeployAction struct {
-	debos.BaseAction         `yaml:",inline"`
+	debos.BaseAction   `yaml:",inline"`
 	SetupFSTab         bool `yaml:"setup-fstab"`
 	SetupKernelCmdline bool `yaml:"setup-kernel-cmdline"`
 }

--- a/actions/ostree_commit_action.go
+++ b/actions/ostree_commit_action.go
@@ -1,3 +1,28 @@
+/*
+OstreeCommit Action
+
+Create OSTree commit from rootfs.
+
+Yaml syntax:
+ - action: ostree-commit
+   repository: repository name
+   branch: branch name
+   subject: commit message
+
+Mandatory properties:
+
+- repository -- path to repository with OSTree structure; the same path is
+used by 'ostree' tool with '--repo' argument.
+This path is relative to 'artifact' directory.
+Please keep in mind -- you will need a root privileges for 'bare' repository
+type (https://ostree.readthedocs.io/en/latest/manual/repo/#repository-types-and-locations).
+
+- branch -- OSTree branch name that should be used for the commit.
+
+Optional properties:
+
+- subject -- one line message with commit description.
+*/
 package actions
 
 import (
@@ -11,10 +36,10 @@ import (
 
 type OstreeCommitAction struct {
 	debos.BaseAction `yaml:",inline"`
-	Repository string
-	Branch     string
-	Subject    string
-	Command    string
+	Repository       string
+	Branch           string
+	Subject          string
+	Command          string
 }
 
 func emptyDir(dir string) {

--- a/actions/ostree_deploy_action.go
+++ b/actions/ostree_deploy_action.go
@@ -1,3 +1,44 @@
+/*
+OstreeDeploy Action
+
+Deploy the OSTree branch to the image.
+If any preparation has been done for rootfs, it can be overwritten
+during this step.
+
+Action 'image-partition' must be called prior to OSTree deploy.
+
+Yaml syntax:
+ - action: ostree-deploy
+   repository: repository name
+   remote_repository: URL
+   branch: branch name
+   os: os name
+   setup-fstab: bool
+   setup-kernel-cmdline: bool
+   appendkernelcmdline: arguments
+
+Mandatory properties:
+
+- remote_repository -- URL to remote OSTree repository for pulling stateroot branch.
+Currently not implemented, please prepare local repository instead.
+
+- repository -- path to repository with OSTree structure.
+This path is relative to 'artifact' directory.
+
+- os -- os deployment name, as explained in:
+https://ostree.readthedocs.io/en/latest/manual/deployment/
+
+- branch -- branch of the repository to use for populating the image.
+
+Optional properties:
+
+- setup-fstab -- create '/etc/fstab' file for image
+
+- setup-kernel-cmdline -- add the information from the 'image-partition'
+action to the configured commandline.
+
+- appendkernelcmdline -- additional kernel command line arguments passed to kernel.
+*/
 package actions
 
 import (
@@ -12,13 +53,13 @@ import (
 )
 
 type OstreeDeployAction struct {
-	debos.BaseAction          `yaml:",inline"`
+	debos.BaseAction    `yaml:",inline"`
 	Repository          string
 	RemoteRepository    string "remote_repository"
 	Branch              string
 	Os                  string
-	SetupFSTab          bool   `yaml:"setup-fstab"`
-	SetupKernelCmdline  bool   `yaml:"setup-kernel-cmdline"`
+	SetupFSTab          bool `yaml:"setup-fstab"`
+	SetupKernelCmdline  bool `yaml:"setup-kernel-cmdline"`
 	AppendKernelCmdline string
 }
 

--- a/actions/overlay_action.go
+++ b/actions/overlay_action.go
@@ -1,3 +1,27 @@
+/*
+Overlay Action
+
+Recursive copy of directory or file to target filesystem.
+
+Yaml syntax:
+ - action: overlay
+   origin: name
+   source: directory
+   destination: directory
+
+Mandatory properties:
+
+- source -- relative path to the directory or file located in path referenced by `origin`.
+In case if this property is absent then pure path referenced by 'origin' will be used.
+
+Optional properties:
+
+- origin -- reference to named file or directory.
+
+- destination -- absolute path in the target rootfs where 'source' will be copied.
+All existing files will be overwritten.
+If destination isn't set '/' of the rootfs will be usedi.
+*/
 package actions
 
 import (

--- a/actions/pack_action.go
+++ b/actions/pack_action.go
@@ -1,3 +1,20 @@
+/*
+Pack Action
+
+Create tarball with filesystem.
+
+Yaml syntax:
+ - action: pack
+   file: filename.ext
+   compression: gz
+
+Mandatory properties:
+
+- file -- name of the output tarball.
+
+- compression -- compression type to use. Only 'gz' is supported at the moment.
+
+*/
 package actions
 
 import (
@@ -8,9 +25,9 @@ import (
 )
 
 type PackAction struct {
-	debos.BaseAction  `yaml:",inline"`
-	Compression string
-	File        string
+	debos.BaseAction `yaml:",inline"`
+	Compression      string
+	File             string
 }
 
 func (pf *PackAction) Run(context *debos.DebosContext) error {

--- a/actions/raw_action.go
+++ b/actions/raw_action.go
@@ -1,3 +1,28 @@
+/*
+Raw Action
+
+Directly write a file to the output image at a given offset.
+This is typically useful for bootloaders.
+
+Yaml syntax:
+ - action: raw
+   origin: name
+   source: filename
+   offset: bytes
+
+Mandatory properties:
+
+- origin -- reference to named file or directory.
+
+- source -- the name of file located in 'origin' to be written into the output image.
+
+Optional properties:
+
+- offset -- offset in bytes for output image file.
+It is possible to use internal templating mechanism of debos to calculate offset
+with sectors (512 bytes) instead of bytes, for instance: '{{ sector 256 }}'.
+The default value is zero.
+*/
 package actions
 
 import (

--- a/actions/run_action.go
+++ b/actions/run_action.go
@@ -1,3 +1,35 @@
+/*
+Run Action
+
+Allows to run any available command or script in the filesystem or
+in host environment.
+
+Yaml syntax:
+ - action: run
+   chroot: bool
+   postprocess: bool
+   script: script name
+   command: command line
+
+Properties 'command' and 'script' are mutually exclusive.
+
+- command -- command with arguments; the command expected to be accessible in
+host's or chrooted environment -- depending on 'chroot' property.
+
+- script -- script with arguments; script must be located in recipe directory.
+
+Optional properties:
+
+- chroot -- run script or command in target filesystem if set to true.
+In other case the command or script is executed within the build process, with
+access to the filesystem and the image. In both cases it is run with root privileges.
+
+- postprocess -- if set script or command is executed after all other commands and
+has access to the image file.
+
+
+Properties 'chroot' and 'postprocess' are mutually exclusive.
+*/
 package actions
 
 import (
@@ -10,11 +42,11 @@ import (
 )
 
 type RunAction struct {
-	debos.BaseAction  `yaml:",inline"`
-	Chroot      bool
-	PostProcess bool
-	Script      string
-	Command     string
+	debos.BaseAction `yaml:",inline"`
+	Chroot           bool
+	PostProcess      bool
+	Script           string
+	Command          string
 }
 
 func (run *RunAction) Verify(context *debos.DebosContext) error {

--- a/actions/unpack_action.go
+++ b/actions/unpack_action.go
@@ -1,3 +1,35 @@
+/*
+Unpack Action
+
+Unpack files from archive to the filesystem.
+Useful for creating target rootfs from saved tarball with prepared file structure.
+
+Only (compressed) tar archives are supported currently.
+
+Yaml syntax:
+ - action: unpack
+   origin: name
+   file: file.ext
+   compression: gz
+
+Mandatory properties:
+
+- file -- archive's file name. It is possible to skip this property if 'origin'
+referenced to downloaded file.
+
+One of the mandatory properties may be omitted with limitations mentioned above.
+It is expected to find archive with name pointed in `file` property inside of `origin` in case if both properties are used.
+
+Optional properties:
+
+- origin -- reference to a named file or directory.
+The default value is 'artifacts' directory in case if this property is omitted.
+
+- compression -- optional hint for unpack allowing to use proper compression method.
+
+Currently only 'gz', bzip2' and 'xz' compression types are supported.
+If not provided an attempt to autodetect the compression type will be done.
+*/
 package actions
 
 import (

--- a/recipe/recipe.go
+++ b/recipe/recipe.go
@@ -95,7 +95,7 @@ func (y *YamlAction) UnmarshalYAML(unmarshal func(interface{}) error) error {
 
 	switch aux.Action {
 	case "debootstrap":
-		y.Action = &actions.DebootstrapAction{}
+		y.Action = actions.NewDebootstrapAction()
 	case "pack":
 		y.Action = &actions.PackAction{}
 	case "unpack":


### PR DESCRIPTION
Add description of each available action and properties allowed by actions.
Used 'godoc' format to keep actions documentation in one place with implementation.
