### PR TITLE
recipe: parse configuration in 'recipe' package

### DIFF
--- a/recipe/recipe.go
+++ b/recipe/recipe.go
@@ -1,3 +1,66 @@
+/*
+Package 'recipe' implements actions mapping to YAML recipe.
+
+Recipe syntax
+
+Recipe is a YAML file which is pre-processed though Golang
+text templating engine (https://golang.org/pkg/text/template)
+
+Recipe is composed of 2 parts:
+
+- header
+
+- actions
+
+Comments are allowed and should be prefixed with '#' symbol.
+
+ # Declare variable 'Var'
+ {{- $Var := "Value" -}}
+
+ # Header
+ architecture: arm64
+
+ # Actions are executed in listed order
+ actions:
+   - action: ActionName1
+     property1: true
+
+   - action: ActionName2
+     # Use value of variable 'Var' defined above
+     property2: {{$Var}}
+
+Mandatory properties for receipt:
+
+- architecture -- target architecture
+
+- actions -- at least one action should be listed
+
+Supported actions
+
+- apt -- https://godoc.org/github.com/go-debos/debos/actions#hdr-Apt_Action
+
+- debootstrap -- https://godoc.org/github.com/go-debos/debos/actions#hdr-Debootstrap_Action
+
+- download -- https://godoc.org/github.com/go-debos/debos/actions#hdr-Download_Action
+
+- filesystem-deploy -- https://godoc.org/github.com/go-debos/debos/actions#hdr-FilesystemDeploy_Action
+
+- image-partition -- https://godoc.org/github.com/go-debos/debos/actions#hdr-ImagePartition_Action
+
+- ostree-commit -- https://godoc.org/github.com/go-debos/debos/actions#hdr-OstreeCommit_Action
+
+- ostree-deploy -- https://godoc.org/github.com/go-debos/debos/actions#hdr-OstreeDeploy_Action
+
+- overlay -- https://godoc.org/github.com/go-debos/debos/actions#hdr-Overlay_Action
+
+- pack -- https://godoc.org/github.com/go-debos/debos/actions#hdr-Pack_Action
+
+- raw -- https://godoc.org/github.com/go-debos/debos/actions#hdr-Raw_Action
+
+- run -- https://godoc.org/github.com/go-debos/debos/actions#hdr-Run_Action
+
+- unpack -- https://godoc.org/github.com/go-debos/debos/actions#hdr-Unpack_Action
+*/
 package recipe
 
 import (

--- a/recipe/recipe_test.go
+++ b/recipe/recipe_test.go
@@ -1,0 +1,182 @@
+package recipe_test
+
+import (
+	"github.com/go-debos/debos/recipe"
+	"github.com/stretchr/testify/assert"
+	"io/ioutil"
+	"os"
+	"testing"
+)
+
+type testRecipe struct {
+	recipe string
+	err    string
+}
+
+// Test if incorrect file has been passed
+func TestParse_incorrect_file(t *testing.T) {
+	var err error
+
+	var tests = []struct {
+		filename string
+		err      string
+	}{
+		{
+			"non-existing.yaml",
+			"open non-existing.yaml: no such file or directory",
+		},
+		{
+			"/proc",
+			"read /proc: is a directory",
+		},
+	}
+
+	for _, test := range tests {
+		r := recipe.Recipe{}
+		err = r.Parse(test.filename)
+		assert.EqualError(t, err, test.err)
+	}
+}
+
+// Check common recipe syntax
+func TestParse_syntax(t *testing.T) {
+
+	var tests = []testRecipe{
+		// Test if all actions are supported
+		{`
+architecture: arm64
+
+actions:
+  - action: apt
+  - action: debootstrap
+  - action: download
+  - action: filesystem-deploy 
+  - action: image-partition
+  - action: ostree-commit
+  - action: ostree-deploy
+  - action: overlay
+  - action: pack
+  - action: raw
+  - action: run
+  - action: unpack
+`,
+			"", // Do not expect failure
+		},
+		// Test of unknown action in list
+		{`
+architecture: arm64
+
+actions:
+  - action: test_unknown_action
+`,
+			"Unknown action: test_unknown_action",
+		},
+		// Test if 'architecture' property absence
+		{`
+actions:
+  - action: raw
+`,
+			"Recipe file must have 'architecture' property",
+		},
+		// Test if no actions listed
+		{`
+architecture: arm64
+`,
+			"Recipe file must have at least one action",
+		},
+		// Test of wrong syntax in Yaml
+		{`wrong`,
+			"yaml: unmarshal errors:\n  line 1: cannot unmarshal !!str `wrong` into recipe.Recipe",
+		},
+		// Test if no actions listed
+		{`
+architecture: arm64
+`,
+			"Recipe file must have at least one action",
+		},
+	}
+
+	for _, test := range tests {
+		runTest(t, test)
+	}
+}
+
+// Check template engine
+func TestParse_template(t *testing.T) {
+
+	var test = testRecipe{
+		// Test template variables
+		`
+{{ $action:= or .action "download" }}
+architecture: arm64
+actions:
+  - action: {{ $action }}
+`,
+		"", // Do not expect failure
+	}
+
+	{ // Test of embedded template
+		r := runTest(t, test)
+		assert.Equalf(t, r.Actions[0].String(), "download",
+			"Fail to use embedded variable definition from recipe:%s\n",
+			test.recipe)
+	}
+
+	{ // Test of user-defined template variable
+		var templateVars = map[string]string{
+			"action": "pack",
+		}
+
+		r := runTest(t, test, templateVars)
+		assert.Equalf(t, r.Actions[0].String(), "pack",
+			"Fail to redefine variable with user-defined map:%s\n",
+			test.recipe)
+	}
+}
+
+// Test of 'sector' function embedded to recipe package
+func TestParse_sector(t *testing.T) {
+	var testSector = testRecipe{
+		// Fail with unknown action
+		`
+architecture: arm64
+
+actions:
+  - action: {{ sector 42 }}
+`,
+		"Unknown action: 21504",
+	}
+	runTest(t, testSector)
+}
+
+func runTest(t *testing.T, test testRecipe, templateVars ...map[string]string) recipe.Recipe {
+	file, err := ioutil.TempFile(os.TempDir(), "recipe")
+	assert.Empty(t, err)
+	defer os.Remove(file.Name())
+
+	file.WriteString(test.recipe)
+	file.Close()
+
+	r := recipe.Recipe{}
+	if len(templateVars) == 0 {
+		err = r.Parse(file.Name())
+	} else {
+		err = r.Parse(file.Name(), templateVars[0])
+	}
+
+	failed := false
+
+	if len(test.err) > 0 {
+		// Expected error?
+		failed = !assert.EqualError(t, err, test.err)
+	} else {
+		// Unexpected error
+		failed = !assert.Empty(t, err)
+	}
+
+	if failed {
+		t.Logf("Failed recipe:%s\n", test.recipe)
+	}
+
+	return r
+}


### PR DESCRIPTION
Recipe configuration file parsing has been moved from main package of 'debos'
tool to package 'recipe'. This change combines all things related to
'debos' configuration file in the single package allowing to re-use parsing
in other tools and simplify tests creation.
Package 'recipe' is now responsible for templating mechanism and YAML parsing.

Signed-off-by: Denis Pynkin <denis.pynkin@collabora.com>