### PR TITLE
Fix typo in CopyTree function

### DIFF
--- a/filesystem.go
+++ b/filesystem.go
@@ -69,7 +69,7 @@ func CopyTree(sourcetree, desttree string) error {
 		case os.ModeSymlink:
 			link, err := os.Readlink(p)
 			if err != nil {
-				log.Panic("Failed to read symlink %s: %v", suffix, err)
+				log.Panicf("Failed to read symlink %s: %v", suffix, err)
 			}
 			os.Symlink(link, target)
 		default:


### PR DESCRIPTION
Fix typo leading to incorrect error message in case of any problems
with links during FS copying.

Signed-off-by: Denis Pynkin <denis.pynkin@collabora.com>