### PR TITLE
actions: debootstrap: add 'merged-usr' property

### DIFF
--- a/actions/debootstrap_action.go
+++ b/actions/debootstrap_action.go
@@ -17,6 +17,14 @@ type DebootstrapAction struct {
 	Variant        string
 	KeyringPackage string `yaml:"keyring-package"`
 	Components     []string
+	MergedUsr      bool `yaml:"merged-usr"`
+}
+
+func NewDebootstrapAction() *DebootstrapAction {
+	d := DebootstrapAction{}
+	// Use filesystem with merged '/usr' by default
+	d.MergedUsr = true
+	return &d
 }
 
 func (d *DebootstrapAction) RunSecondStage(context debos.DebosContext) error {
@@ -39,8 +47,11 @@ func (d *DebootstrapAction) RunSecondStage(context debos.DebosContext) error {
 
 func (d *DebootstrapAction) Run(context *debos.DebosContext) error {
 	d.LogStart()
-	cmdline := []string{"debootstrap", "--no-check-gpg",
-		"--merged-usr"}
+	cmdline := []string{"debootstrap", "--no-check-gpg"}
+
+	if d.MergedUsr {
+		cmdline = append(cmdline, "--merged-usr")
+	}
 
 	if d.KeyringPackage != "" {
 		cmdline = append(cmdline, fmt.Sprintf("--keyring=%s", d.KeyringPackage))

--- a/recipe/recipe.go
+++ b/recipe/recipe.go
@@ -95,7 +95,7 @@ func (y *YamlAction) UnmarshalYAML(unmarshal func(interface{}) error) error {
 
 	switch aux.Action {
 	case "debootstrap":
-		y.Action = &actions.DebootstrapAction{}
+		y.Action = actions.NewDebootstrapAction()
 	case "pack":
 		y.Action = &actions.PackAction{}
 	case "unpack":


### PR DESCRIPTION
Add new property 'merged-usr' for 'debootstrap' action.
By default it is set to 'true' for usage filesystem with
merged '/usr'. If set to 'false' then classic FHS will be used.

Fixes #17.

Signed-off-by: Denis Pynkin <denis.pynkin@collabora.com>