### PR TITLE
debug: run interactive shell on error

### DIFF
--- a/action.go
+++ b/action.go
@@ -17,6 +17,7 @@ type DebosContext struct {
 	ImageKernelRoot string       // Kernel cmdline root= snippet for the / of the image
 	RecipeDir       string
 	Architecture    string
+	DebugShell      string
 	Origins         map[string]string
 }
 

--- a/debug.go
+++ b/debug.go
@@ -1,0 +1,31 @@
+package debos
+
+import (
+	"fmt"
+	"log"
+	"os"
+)
+
+/*
+DebugShell function launches an interactive shell for
+debug and problems investigation.
+*/
+func DebugShell(context DebosContext) {
+
+	if len(context.DebugShell) == 0 {
+		return
+	}
+
+	pa := os.ProcAttr{
+		Files: []*os.File{os.Stdin, os.Stdout, os.Stderr},
+		Dir:   context.Scratchdir,
+	}
+
+	// Start an interactive shell for debug.
+	log.Printf(">>> Starting a debug shell")
+	if proc, err := os.StartProcess(context.DebugShell, []string{}, &pa); err != nil {
+		fmt.Printf("Failed: %s\n", err)
+	} else {
+		proc.Wait()
+	}
+}


### PR DESCRIPTION
Launch interactive shell in context of failed action for issues investigation and debug.

Add options to debos:
--debug-shell -- to start a shell in case of any failure
--shell <path> -- use selected shell instead of default bash

Fixes #30 

Signed-off-by: Denis Pynkin <denis.pynkin@collabora.com>