### PR TITLE
debos: allow to use external image for '/scratch'

### DIFF
--- a/cmd/debos/debos.go
+++ b/cmd/debos/debos.go
@@ -6,7 +6,9 @@ import (
 	"log"
 	"os"
 	"path"
+	"path/filepath"
 
+	"github.com/docker/go-units"
 	"github.com/go-debos/debos"
 	"github.com/go-debos/debos/recipe"
 	"github.com/jessevdk/go-flags"
@@ -23,14 +25,56 @@ func checkError(context debos.DebosContext, err error, a debos.Action, stage str
 	return 1
 }
 
+// If option BuildStorageLocation has been passed.
+// Prepare the image formatted as ext4 and setup to mount it to '/scratch'
+// in fake machine
+func prepareBuildImage(context debos.DebosContext, buildImagePath string, buildImageSize int64) (string, error) {
+	fi, err := os.Stat(buildImagePath)
+	if err != nil {
+		return "", err
+	}
+	if mode := fi.Mode(); mode.IsDir() != true {
+		return "", fmt.Errorf("Location for temporary build image must have directory type.")
+	}
+
+	buildImage, err := ioutil.TempFile(buildImagePath, ".debos-build-")
+	if err != nil {
+		return "", err
+	}
+
+	if err := buildImage.Truncate(buildImageSize); err != nil {
+		return buildImage.Name(), err
+	}
+
+	// Format the whole disk image disabling journal support
+	cmdline := []string{}
+	cmdline = append(cmdline, "mkfs.ext4", "-q", buildImage.Name())
+	cmdline = append(cmdline, "-O", "^has_journal")
+	cmd := debos.Command{}
+	if err := cmd.Run(context.Scratchdir, cmdline...); err != nil {
+		return buildImage.Name(), err
+	}
+
+	cmdline = []string{}
+	cmdline = append(cmdline, "mount", "-t", "ext4", buildImage.Name(), context.Scratchdir, "-o", "loop")
+	cmd = debos.Command{}
+	if err := cmd.Run(context.Scratchdir, cmdline...); err != nil {
+		return buildImage.Name(), err
+	}
+
+	return buildImage.Name(), nil
+}
+
 func main() {
 	var context debos.DebosContext
 	var options struct {
-		ArtifactDir   string            `long:"artifactdir"`
-		InternalImage string            `long:"internal-image" hidden:"true"`
-		TemplateVars  map[string]string `short:"t" long:"template-var" description:"Template variables"`
-		DebugShell    bool              `long:"debug-shell" description:"Fall into interactive shell on error"`
-		Shell         string            `short:"s" long:"shell" description:"Redefine interactive shell binary (default: bash)" optionsl:"" default:"/bin/bash"`
+		ArtifactDir          string            `long:"artifactdir"`
+		InternalImage        string            `long:"internal-image" hidden:"true"`
+		TemplateVars         map[string]string `short:"t" long:"template-var" description:"Template variables"`
+		DebugShell           bool              `long:"debug-shell" description:"Fall into interactive shell on error"`
+		Shell                string            `short:"s" long:"shell" description:"Redefine interactive shell binary (default: bash)" optionsl:"" default:"/bin/bash"`
+		BuildStorageLocation string            `short:"b" long:"build-storage" description:"Directory for temporary build image"`
+		BuildStorageSize     string            `long:"build-storage-size" description:"The size of the temporary build image" default:"10gB"`
 	}
 
 	var exitcode int = 0
@@ -128,6 +172,10 @@ func main() {
 			args = append(args, "--shell", fmt.Sprintf("%s", options.Shell))
 		}
 
+		if len(options.BuildStorageLocation) != 0 {
+			args = append(args, "--build-storage", options.BuildStorageLocation)
+			args = append(args, "--build-storage-size", options.BuildStorageSize)
+		}
 		for _, a := range r.Actions {
 			err = a.PreMachine(&context, m, &args)
 			if exitcode = checkError(context, err, a, "PreMachine"); exitcode != 0 {
@@ -140,7 +188,6 @@ func main() {
 			fmt.Println(err)
 			return
 		}
-
 		if exitcode != 0 {
 			return
 		}
@@ -154,6 +201,35 @@ func main() {
 
 		log.Printf("==== Recipe done ====")
 		return
+	}
+	// Prepare build image
+	if len(options.BuildStorageLocation) != 0 {
+		// Exit with errorcode = 1 in case of error
+		exitcode = 1
+
+		buildImageSize, err := units.FromHumanSize(options.BuildStorageSize)
+		if err != nil {
+			log.Println(err)
+			return
+		}
+
+		blddir, err := filepath.Abs(options.BuildStorageLocation)
+		if err != nil {
+			log.Println(err)
+			return
+		}
+
+		buildImage, err := prepareBuildImage(context, blddir, buildImageSize)
+		if len(buildImage) != 0 {
+			defer os.Remove(buildImage)
+		}
+		if err != nil {
+			log.Println(err)
+			return
+		}
+
+		// restore exitcode to success
+		exitcode = 0
 	}
 
 	if !fakemachine.InMachine() {


### PR DESCRIPTION
Create temporary image to mount to '/scratch' directory.
Fixes problems with preparing OS packs requires a lot of disk space for
packages.

Fixes #29

Signed-off-by: Denis Pynkin <denis.pynkin@collabora.com>