### PR TITLE
debos: add error message if recipe file is absent

### DIFF
--- a/cmd/debos/debos.go
+++ b/cmd/debos/debos.go
@@ -68,8 +68,15 @@ func main() {
 	file = debos.CleanPath(file)
 
 	r := recipe.Recipe{}
+	if _, err := os.Stat(file); os.IsNotExist(err) {
+		log.Println(err)
+		exitcode = 1
+		return
+	}
 	if err := r.Parse(file, options.TemplateVars); err != nil {
-		panic(err)
+		log.Println(err)
+		exitcode = 1
+		return
 	}
 
 	/* If fakemachine is supported the outer fake machine will never use the


### PR DESCRIPTION
Warn user and return an error exit code in case if recipe file is not exists.

Signed-off-by: Denis Pynkin <denis.pynkin@collabora.com>