### PR TITLE
Adjust for fakemachine image API update

### DIFF
--- a/actions/image_partition_action.go
+++ b/actions/image_partition_action.go
@@ -193,13 +193,13 @@ func (i ImagePartitionAction) getPartitionDevice(number int, context debos.Debos
 
 func (i ImagePartitionAction) PreMachine(context *debos.DebosContext, m *fakemachine.Machine,
 	args *[]string) error {
-	err := m.CreateImage(i.ImageName, i.size)
+	image, err := m.CreateImage(i.ImageName, i.size)
 	if err != nil {
 		return err
 	}
 
-	context.Image = "/dev/vda"
-	*args = append(*args, "--internal-image", "/dev/vda")
+	context.Image = image
+	*args = append(*args, "--internal-image", image)
 	return nil
 }
 


### PR DESCRIPTION
Future API for fakemachine will return the device path of a created
image inside a fakemachine; Update debos to support that, which also
nicely removes the /dev/vda hardcoding

Signed-off-by: Sjoerd Simons <sjoerd.simons@collabora.co.uk>