### PR TITLE
actions: image-partition: allow to use disks by ID

### DIFF
--- a/actions/image_partition_action.go
+++ b/actions/image_partition_action.go
@@ -181,11 +181,17 @@ func (i *ImagePartitionAction) generateKernelRoot(context *debos.DebosContext) e
 }
 
 func (i ImagePartitionAction) getPartitionDevice(number int, context debos.DebosContext) string {
+	suffix := "p"
+	/* Check partition naming first: if used 'by-id'i naming convention */
+	if strings.Contains(context.Image, "/disk/by-id/") {
+		suffix = "-part"
+	}
+
 	/* If the iamge device has a digit as the last character, the partition
 	 * suffix is p<number> else it's just <number> */
 	last := context.Image[len(context.Image)-1]
 	if last >= '0' && last <= '9' {
-		return fmt.Sprintf("%sp%d", context.Image, number)
+		return fmt.Sprintf("%s%s%d", context.Image, suffix, number)
 	} else {
 		return fmt.Sprintf("%s%d", context.Image, number)
 	}


### PR DESCRIPTION
Naming scheme by disk ID provided by udevd uses '-part' suffix for partitions.
Allow to use correct partition names in case if disk path is
'/dev/disk/by-id/'.

Signed-off-by: Denis Pynkin <denis.pynkin@collabora.com>