### PR TITLE
actions: filesystem_deploy: fix path for 'filesystem' origin

### DIFF
--- a/actions/filesystem_deploy_action.go
+++ b/actions/filesystem_deploy_action.go
@@ -112,6 +112,7 @@ func (fd *FilesystemDeployAction) Run(context *debos.DebosContext) error {
 		return fmt.Errorf("rootfs deploy failed: %v", err)
 	}
 	context.Rootdir = context.ImageMntDir
+	context.Origins["filesystem"] = context.ImageMntDir
 
 	if fd.SetupFSTab {
 		err = fd.setupFSTab(context)


### PR DESCRIPTION
Use correct path for origin 'filesystem'. It must be changed
as soon as we point 'Rootdir' to mounted image.

Signed-off-by: Denis Pynkin <denis.pynkin@collabora.com>