### PR TITLE
actions: image-partition: add error check on 'udevadm' call

### DIFF
--- a/actions/image_partition_action.go
+++ b/actions/image_partition_action.go
@@ -303,8 +303,11 @@ func (i ImagePartitionAction) Run(context *debos.DebosContext) error {
 		}
 
 		// Give a chance for udevd to create proper symlinks
-		debos.Command{}.Run("udevadm", "udevadm", "settle", "-t", "5",
+		err = debos.Command{}.Run("udevadm", "udevadm", "settle", "-t", "5",
 			"-E", i.getPartitionDevice(p.number, *context))
+		if err != nil {
+			return err
+		}
 
 		err = i.formatPartition(p, *context)
 		if err != nil {


### PR DESCRIPTION
Add error check for 'udevadm' to be sure it is works as expected.

Signed-off-by: Denis Pynkin <denis.pynkin@collabora.com>