### PR TITLE
actions: image-partition: do not need UUID on partitions without FS

### DIFF
--- a/actions/image_partition_action.go
+++ b/actions/image_partition_action.go
@@ -236,11 +236,13 @@ func (i ImagePartitionAction) formatPartition(p *Partition, context debos.DebosC
 		}
 	}
 
-	uuid, err := exec.Command("blkid", "-o", "value", "-s", "UUID", "-p", "-c", "none", path).Output()
-	if err != nil {
-		return fmt.Errorf("Failed to get uuid: %s", err)
+	if p.FS != "none" {
+		uuid, err := exec.Command("blkid", "-o", "value", "-s", "UUID", "-p", "-c", "none", path).Output()
+		if err != nil {
+			return fmt.Errorf("Failed to get uuid: %s", err)
+		}
+		p.FSUUID = strings.TrimSpace(string(uuid[:]))
 	}
-	p.FSUUID = strings.TrimSpace(string(uuid[:]))
 
 	return nil
 }


### PR DESCRIPTION
Do not try to start 'blkid' on partitions without filesystem.
Modern versions of 'blkid' return empty string and error code 0.
Old versions of 'blkid'  (Debian Jessie) fails with error code 2
and this breaks the build.

Signed-off-by: Denis Pynkin <denis.pynkin@collabora.com>