### PR TITLE
action: run: fix passing of multiple '/' symbols for script arguments

### DIFF
--- a/actions/run_action.go
+++ b/actions/run_action.go
@@ -87,15 +87,14 @@ func (run *RunAction) doRun(context debos.DebosContext) error {
 	}
 
 	if run.Script != "" {
-		run.Script = debos.CleanPathAt(run.Script, context.RecipeDir)
+		script := strings.SplitN(run.Script, " ", 2)
+		script[0] = debos.CleanPathAt(script[0], context.RecipeDir)
 		if run.Chroot {
-			script := strings.Split(run.Script, " ")
 			scriptpath := path.Dir(script[0])
 			cmd.AddBindMount(scriptpath, "/script")
-			cmdline = []string{strings.Replace(run.Script, scriptpath, "/script", 1)}
-		} else {
-			cmdline = []string{run.Script}
+			script[0] = strings.Replace(script[0], scriptpath, "/script", 1)
 		}
+		cmdline = []string{strings.Join(script, " ")}
 		label = path.Base(run.Script)
 	} else {
 		cmdline = []string{run.Command}


### PR DESCRIPTION
Need to pass URI as a script argument, but CleanPathAt() convert
multiple slash symbols to the single one.

Signed-off-by: Denis Pynkin <denis.pynkin@collabora.com>