### PR TITLE
action: ostree-deploy: fix 'filesystem' origin

### DIFF
--- a/actions/ostree_deploy_action.go
+++ b/actions/ostree_deploy_action.go
@@ -103,6 +103,7 @@ func (ot *OstreeDeployAction) Run(context *debos.DebosContext) error {
 			return fmt.Errorf("rootfs deploy failed: %v", err)
 		}
 		context.Rootdir = context.ImageMntDir
+		context.Origins["filesystem"] = context.ImageMntDir
 	}
 
 	repoPath := "file://" + path.Join(context.Artifactdir, ot.Repository)


### PR DESCRIPTION
Use correct path for `filesystem` origin if rootfs has been
changed to image mountpoint.

Signed-off-by: Denis Pynkin <denis.pynkin@collabora.com>