### PR TITLE
Improve help and documentation

### DIFF
--- a/actions/pack_action.go
+++ b/actions/pack_action.go
@@ -10,7 +10,7 @@ Yaml syntax:
 
 Mandatory properties:
 
-- file -- name of the output tarball.
+- file -- name of the output tarball, relative to the artifact directory.
 
 - compression -- compression type to use. Only 'gz' is supported at the moment.
 

--- a/actions/run_action.go
+++ b/actions/run_action.go
@@ -21,8 +21,10 @@ host's or chrooted environment -- depending on 'chroot' property.
 Optional properties:
 
 - chroot -- run script or command in target filesystem if set to true.
-In other case the command or script is executed within the build process, with
-access to the filesystem and the image. In both cases it is run with root privileges.
+Otherwise the command or script is executed within the build process, with
+access to the filesystem ($ROOTDIR), the image if any ($IMAGE), the
+recipe directory ($RECIPEDIR) and the artifact directory ($ARTIFACTDIR).
+In both cases it is run with root privileges.
 
 - postprocess -- if set script or command is executed after all other commands and
 has access to the image file.

--- a/cmd/debos/debos.go
+++ b/cmd/debos/debos.go
@@ -29,7 +29,7 @@ func main() {
 	var options struct {
 		ArtifactDir   string            `long:"artifactdir" description:"Directory for packed archives and ostree repositories (default: current directory)"`
 		InternalImage string            `long:"internal-image" hidden:"true"`
-		TemplateVars  map[string]string `short:"t" long:"template-var" description:"Template variables"`
+		TemplateVars  map[string]string `short:"t" long:"template-var" description:"Template variables (use -t VARIABLE:VALUE syntax)"`
 		DebugShell    bool              `long:"debug-shell" description:"Fall into interactive shell on error"`
 		Shell         string            `short:"s" long:"shell" description:"Redefine interactive shell binary (default: bash)" optionsl:"" default:"/bin/bash"`
 		ScratchSize   string            `long:"scratchsize" description:"Size of disk backed scratch space"`

--- a/cmd/debos/debos.go
+++ b/cmd/debos/debos.go
@@ -27,7 +27,7 @@ func checkError(context debos.DebosContext, err error, a debos.Action, stage str
 func main() {
 	var context debos.DebosContext
 	var options struct {
-		ArtifactDir   string            `long:"artifactdir"`
+		ArtifactDir   string            `long:"artifactdir" description:"Directory for packed archives and ostree repositories (default: current directory)"`
 		InternalImage string            `long:"internal-image" hidden:"true"`
 		TemplateVars  map[string]string `short:"t" long:"template-var" description:"Template variables"`
 		DebugShell    bool              `long:"debug-shell" description:"Fall into interactive shell on error"`


### PR DESCRIPTION
This branch makes some minor documentation fixes that I would have found useful when learning to use debos. See also #84 (which doesn't duplicate this).

* run: Document the environment variables that will be set if !chroot
* pack: Document archive as relative to artifacts directory
* cmd: Document artifacts directory
* cmd: Give a hint about template variable syntax