### PR TITLE
debootstrap: Output the debootstrap log if it fails

### DIFF
--- a/actions/debootstrap_action.go
+++ b/actions/debootstrap_action.go
@@ -83,7 +83,14 @@ func (d *DebootstrapAction) RunSecondStage(context debos.DebosContext) error {
 	// Can't use nspawn for debootstrap as it wants to create device nodes
 	c.ChrootMethod = debos.CHROOT_METHOD_CHROOT
 
-	return c.Run("Debootstrap (stage 2)", cmdline...)
+	err := c.Run("Debootstrap (stage 2)", cmdline...)
+
+	if (err != nil) {
+		log := path.Join(context.Rootdir, "debootstrap/debootstrap.log")
+		_ = debos.Command{}.Run("debootstrap.log", "cat", log)
+	}
+
+	return err
 }
 
 func (d *DebootstrapAction) Run(context *debos.DebosContext) error {
@@ -131,6 +138,8 @@ func (d *DebootstrapAction) Run(context *debos.DebosContext) error {
 	err := debos.Command{}.Run("Debootstrap", cmdline...)
 
 	if err != nil {
+		log := path.Join(context.Rootdir, "debootstrap/debootstrap.log")
+		_ = debos.Command{}.Run("debootstrap.log", "cat", log)
 		return err
 	}
 


### PR DESCRIPTION
In failure cases, debootstrap's stdout/stderr doesn't usually tell
the whole story.

Signed-off-by: Simon McVittie <smcv@collabora.com>
Fixes: #83