### PR TITLE
Add format-image action

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Some of the actions provided by debos to customize and produce images are:
 * debootstrap: construct the target rootfs with debootstrap
 * download: download a single file from the internet
 * filesystem-deploy: deploy a root filesystem to an image previously created
+* format-image: create an image file and format it
 * image-partition: create an image file, make partitions and format them
 * ostree-commit: create an OSTree commit from rootfs
 * ostree-deploy: deploy an OSTree branch to the image

--- a/actions/filesystem_deploy_action.go
+++ b/actions/filesystem_deploy_action.go
@@ -2,7 +2,7 @@
 FilesystemDeploy Action
 
 Deploy prepared root filesystem to output image. This action requires
-'image-partition' action to be executed before it.
+'image-partition' or 'format-image' action to be executed before it.
 
 Yaml syntax:
  - action: filesystem-deploy

--- a/actions/format_image_action.go
+++ b/actions/format_image_action.go
@@ -1,0 +1,166 @@
+/*
+FormatImage Action
+
+This action creates an image file and formats it with a filesystem.
+
+Yaml syntax:
+ - action: format-image
+   imagename: image_name
+   imagesize: size
+   fs: filesystem
+   blocksize: 4096
+
+Mandatory properties:
+
+- imagename -- the name of the image file.
+
+- imagesize -- generated image size in human-readable form, examples: 100MB, 1GB, etc.
+
+- fs -- filesystem type used for formatting.
+
+Optional properties:
+
+- blocksize -- size of blocks in bytes, for ext fs only. Valid values are 1024, 2048 and 4096.
+*/
+
+package actions
+
+import (
+	"fmt"
+	"github.com/docker/go-units"
+	"github.com/go-debos/fakemachine"
+	"os"
+	"os/exec"
+	"path"
+	"strings"
+	"syscall"
+
+	"github.com/go-debos/debos"
+)
+
+type FormatImageAction struct {
+	debos.BaseAction `yaml:",inline"`
+	ImageName        string
+	ImageSize        string
+	FS               string
+	BlockSize        int
+	size             int64
+	usingLoop        bool
+}
+
+func (i FormatImageAction) format(context debos.DebosContext) error {
+	label := fmt.Sprintf("Formatting image")
+
+	cmdline := []string{}
+	switch i.FS {
+	case "vfat":
+		cmdline = append(cmdline, "mkfs.vfat")
+	case "btrfs":
+		// Force formatting to prevent failure in case if partition was formatted already
+		cmdline = append(cmdline, "mkfs.btrfs", "-f")
+	case "none":
+	default:
+		cmdline = append(cmdline, fmt.Sprintf("mkfs.%s", i.FS))
+	}
+
+	if len(cmdline) != 0 {
+		cmdline = append(cmdline, context.Image)
+
+		cmd := debos.Command{}
+		if err := cmd.Run(label, cmdline...); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (i FormatImageAction) PreMachine(context *debos.DebosContext, m *fakemachine.Machine,
+	args *[]string) error {
+	image, err := m.CreateImage(i.ImageName, i.size)
+	if err != nil {
+		return err
+	}
+
+	context.Image = image
+	*args = append(*args, "--internal-image", image)
+	return nil
+}
+
+func (i *FormatImageAction) PreNoMachine(context *debos.DebosContext) error {
+	img, err := os.OpenFile(i.ImageName, os.O_WRONLY|os.O_CREATE, 0666)
+	if err != nil {
+		return fmt.Errorf("Couldn't open image file: %v", err)
+	}
+
+	err = img.Truncate(i.size)
+	if err != nil {
+		return fmt.Errorf("Couldn't resize image file: %v", err)
+	}
+
+	img.Close()
+
+	loop, err := exec.Command("losetup", "-f", "--show", i.ImageName).Output()
+	if err != nil {
+		return fmt.Errorf("Failed to setup loop device")
+	}
+	context.Image = strings.TrimSpace(string(loop[:]))
+	i.usingLoop = true
+
+	return nil
+}
+
+func (i *FormatImageAction) Run(context *debos.DebosContext) error {
+	i.LogStart()
+
+	err := i.format(*context)
+	if err != nil {
+		return err
+	}
+
+	context.ImageMntDir = path.Join(context.Scratchdir, "mnt")
+	os.MkdirAll(context.ImageMntDir, 0755)
+	err = syscall.Mount(context.Image, context.ImageMntDir, i.FS, 0, "")
+	if err != nil {
+		return fmt.Errorf("Mount failed: %v", err)
+	}
+
+	return nil
+}
+
+func (i FormatImageAction) Cleanup(context debos.DebosContext) error {
+	syscall.Unmount(context.ImageMntDir, 0)
+
+	if i.usingLoop {
+		exec.Command("losetup", "-d", context.Image).Run()
+	}
+
+	return nil
+}
+
+func (i *FormatImageAction) Verify(context *debos.DebosContext) error {
+	switch i.FS {
+	case "fat32":
+		i.FS = "vfat"
+	case "":
+		return fmt.Errorf("Missing fs type")
+	}
+
+	size, err := units.FromHumanSize(i.ImageSize)
+	if err != nil {
+		return fmt.Errorf("Failed to parse image size: %s", i.ImageSize)
+	}
+	i.size = size
+
+	switch i.BlockSize {
+	case 0:
+	case 1024, 2048, 4096:
+		if !strings.HasPrefix(i.FS, "ext") {
+			return fmt.Errorf("Blockize only valid for ext filesystems")
+		}
+	default:
+		return fmt.Errorf("Invalid value for blocksize")
+	}
+
+	return nil
+}

--- a/image.go
+++ b/image.go
@@ -1,0 +1,68 @@
+package debos
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func CreateImage(imagepath string, size int64) error {
+	img, err := os.OpenFile(imagepath, os.O_WRONLY|os.O_CREATE, 0666)
+	if err != nil {
+		return fmt.Errorf("Couldn't open image file: %v", err)
+	}
+
+	err = img.Truncate(size)
+	if err != nil {
+		return fmt.Errorf("Couldn't resize image file: %v", err)
+	}
+
+	img.Close()
+
+	return nil
+}
+
+func Format(cmdlabel string, imagepath string, fs string, label string) error {
+	cmdline := []string{}
+
+	switch fs {
+	case "vfat":
+		cmdline = append(cmdline, "mkfs.vfat", "-n", label)
+	case "btrfs":
+		// Force formatting to prevent failure in case partition was formatted already
+		cmdline = append(cmdline, "mkfs.btrfs", "-L", label, "-f")
+	case "none":
+	default:
+		cmdline = append(cmdline, fmt.Sprintf("mkfs.%s", fs), "-L", label)
+	}
+
+	if len(cmdline) != 0 {
+		cmdline = append(cmdline, imagepath)
+
+		cmd := Command{}
+		if err := cmd.Run(cmdlabel, cmdline...); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func SetupLoopDevice(imagepath string) (string, error) {
+	loop, err := exec.Command("losetup", "-f", "--show", imagepath).Output()
+	if err != nil {
+		return "", fmt.Errorf("Failed to setup loop device: %v", err)
+	}
+
+	return strings.TrimSpace(string(loop[:])), nil
+}
+
+func DetachLoopDevice(imagepath string) error {
+	err := exec.Command("losetup", "-d", imagepath).Run()
+	if err != nil {
+		return fmt.Errorf("Failed to detach loop device: %v", err)
+	}
+
+	return nil
+}

--- a/recipe/recipe.go
+++ b/recipe/recipe.go
@@ -45,6 +45,8 @@ Supported actions
 
 - filesystem-deploy -- https://godoc.org/github.com/go-debos/debos/actions#hdr-FilesystemDeploy_Action
 
+- format-image  -- https://godoc.org/github.com/go-debos/debos/actions#hdr-FormatImage_Action
+
 - image-partition -- https://godoc.org/github.com/go-debos/debos/actions#hdr-ImagePartition_Action
 
 - ostree-commit -- https://godoc.org/github.com/go-debos/debos/actions#hdr-OstreeCommit_Action
@@ -110,6 +112,8 @@ func (y *YamlAction) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		y.Action = actions.NewOstreeDeployAction()
 	case "overlay":
 		y.Action = &actions.OverlayAction{}
+	case "format-image":
+		y.Action = &actions.FormatImageAction{}
 	case "image-partition":
 		y.Action = &actions.ImagePartitionAction{}
 	case "filesystem-deploy":

--- a/recipe/recipe_test.go
+++ b/recipe/recipe_test.go
@@ -51,6 +51,7 @@ actions:
   - action: debootstrap
   - action: download
   - action: filesystem-deploy 
+  - action: format-image
   - action: image-partition
   - action: ostree-commit
   - action: ostree-deploy


### PR DESCRIPTION
format-image creates an image file and formats it with a filesystem. It
is meant to be followed by the 'filesystem-deploy' action.

This action is useful to prepare images that can be copied "as is" on a
block device, for example one could prepare a rootfs image and install
it with a command such as:

    dd if=rootfs.img of=/dev/sda1

Signed-off-by: Arnaud Rebillout <arnaud.rebillout@collabora.com>