### PR TITLE
ostree-commit: Disable fsync to reduce I/O load

### DIFF
--- a/actions/ostree_commit_action.go
+++ b/actions/ostree_commit_action.go
@@ -77,6 +77,7 @@ func (ot *OstreeCommitAction) Run(context *debos.DebosContext) error {
 
 	opts := otbuiltin.NewCommitOptions()
 	opts.Subject = ot.Subject
+	opts.Fsync = false
 	ret, err := repo.Commit(context.Rootdir, ot.Branch, opts)
 	if err != nil {
 		return err


### PR DESCRIPTION
Debos is likely to be used on ephemeral repositories, so using `fsync`
slows down things without much benefit.