### PR TITLE
Cleanup

### DIFF
--- a/action.go
+++ b/action.go
@@ -6,6 +6,14 @@ import (
 	"log"
 )
 
+type DebosState int
+
+// Represent the current state of Debos
+const (
+	Success DebosState = iota
+	Failed
+)
+
 // Mapping from partition name as configured in the image-partition action to
 // device path for usage by other actions
 type Partition struct {
@@ -27,6 +35,7 @@ type DebosContext struct {
 	Architecture    string
 	DebugShell      string
 	Origins         map[string]string
+	State           DebosState
 }
 
 type Action interface {
@@ -35,8 +44,13 @@ type Action interface {
 	PreMachine(context *DebosContext, m *fakemachine.Machine, args *[]string) error
 	PreNoMachine(context *DebosContext) error
 	Run(context *DebosContext) error
-	Cleanup(context DebosContext) error
-	PostMachine(context DebosContext) error
+	// Cleanup() method gets called only if the Run for an action
+	// was started and in the same machine (host or fake) as Run has run
+	Cleanup(context *DebosContext) error
+	PostMachine(context *DebosContext) error
+	// PostMachineCleanup() gets called for all actions if Pre*Machine() method
+	// has run for Action. This method is always executed on the host with user's permissions.
+	PostMachineCleanup(context *DebosContext) error
 	String() string
 }
 
@@ -55,10 +69,11 @@ func (b *BaseAction) PreMachine(context *DebosContext,
 	args *[]string) error {
 	return nil
 }
-func (b *BaseAction) PreNoMachine(context *DebosContext) error { return nil }
-func (b *BaseAction) Run(context *DebosContext) error          { return nil }
-func (b *BaseAction) Cleanup(context DebosContext) error       { return nil }
-func (b *BaseAction) PostMachine(context DebosContext) error   { return nil }
+func (b *BaseAction) PreNoMachine(context *DebosContext) error       { return nil }
+func (b *BaseAction) Run(context *DebosContext) error                { return nil }
+func (b *BaseAction) Cleanup(context *DebosContext) error            { return nil }
+func (b *BaseAction) PostMachine(context *DebosContext) error        { return nil }
+func (b *BaseAction) PostMachineCleanup(context *DebosContext) error { return nil }
 func (b *BaseAction) String() string {
 	if b.Description == "" {
 		return b.Action

--- a/actions/image_partition_action.go
+++ b/actions/image_partition_action.go
@@ -388,6 +388,19 @@ func (i ImagePartitionAction) Cleanup(context *debos.DebosContext) error {
 	return nil
 }
 
+func (i ImagePartitionAction) PostMachineCleanup(context *debos.DebosContext) error {
+	image := path.Join(context.Artifactdir, i.ImageName)
+	/* Remove the image in case of any action failure */
+	if context.State != debos.Success {
+		if _, err := os.Stat(image); !os.IsNotExist(err) {
+			if err = os.Remove(image); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
 func (i *ImagePartitionAction) Verify(context *debos.DebosContext) error {
 	if len(i.GptGap) > 0 {
 		log.Println("WARNING: special version of parted is needed for 'gpt_gap' option")

--- a/actions/image_partition_action.go
+++ b/actions/image_partition_action.go
@@ -374,7 +374,7 @@ func (i ImagePartitionAction) Run(context *debos.DebosContext) error {
 	return nil
 }
 
-func (i ImagePartitionAction) Cleanup(context debos.DebosContext) error {
+func (i ImagePartitionAction) Cleanup(context *debos.DebosContext) error {
 	for idx := len(i.Mountpoints) - 1; idx >= 0; idx-- {
 		m := i.Mountpoints[idx]
 		mntpath := path.Join(context.ImageMntDir, m.Mountpoint)

--- a/actions/run_action.go
+++ b/actions/run_action.go
@@ -128,9 +128,9 @@ func (run *RunAction) Run(context *debos.DebosContext) error {
 	return run.doRun(*context)
 }
 
-func (run *RunAction) PostMachine(context debos.DebosContext) error {
+func (run *RunAction) PostMachine(context *debos.DebosContext) error {
 	if !run.PostProcess {
 		return nil
 	}
-	return run.doRun(context)
+	return run.doRun(*context)
 }


### PR DESCRIPTION
Reworked cleanup logic allow to remove artifacts created by Per(No)Machine() methods.
Cleanup is now done in reverse order instead of listed in recipe file.