### PR TITLE
README.md: add install dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,12 +45,12 @@ https://godoc.org/github.com/go-debos/debos/actions
 
 ## Installation (under Debian)
 
-    sudo apt install golang
-    sudo apt install libglib2.0-dev libostree-dev
+    sudo apt install golang git libglib2.0-dev libostree-dev qemu-system-x86 \
+         qemu-user-static debootstrap systemd-container
     export GOPATH=/opt/src/gocode # or whatever suites your needs
     go get -u github.com/go-debos/debos/cmd/debos
     /opt/src/gocode/bin/debos --help
-    
+
 ## Simple example
 
 The following example will create a arm64 image, install several


### PR DESCRIPTION
Signed-off-by: Maciej Pijanowski <maciej.pijanowski@3mdeb.com>

`debootstrap` is quite obvious, but I think worth mentioning
`qemu` packages are required by `fakemachine`