### PR TITLE
Recognize all the mips architectures in Debian: mips, mipsel, mips6el

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -176,6 +176,12 @@ func newQemuHelper(c Command) qemuHelper {
 		q.qemusrc = "/usr/bin/qemu-arm-static"
 	case "arm64":
 		q.qemusrc = "/usr/bin/qemu-aarch64-static"
+	case "mips":
+		q.qemusrc = "/usr/bin/qemu-mips-static"
+	case "mipsel":
+		q.qemusrc = "/usr/bin/qemu-mipsel-static"
+	case "mips64el":
+		q.qemusrc = "/usr/bin/qemu-mips64el-static"
 	case "riscv64":
 		q.qemusrc = "/usr/bin/qemu-riscv64-static"
 	case "amd64", "i386":


### PR DESCRIPTION

Signed-off-by: Ana Guerrero Lopez <ana.guerrero@collabora.com>
