### PR TITLE
debootstrap_action: add defaults for Mirror and Components

### DIFF
--- a/actions/debootstrap_action.go
+++ b/actions/debootstrap_action.go
@@ -64,8 +64,12 @@ func NewDebootstrapAction() *DebootstrapAction {
 	d.MergedUsr = true
 	// Be secure by default
 	d.CheckGpg = true
-	return &d
+	// Use main as default component
+	d.Components = []string {"main"}
+	// Use default mirror
+	d.Mirror = "http://deb.debian.org/debian"
 
+	return &d
 }
 
 func (d *DebootstrapAction) RunSecondStage(context debos.DebosContext) error {


### PR DESCRIPTION
Run() creates a sources.list file based on Mirror and Components from
the input file. However the only mandatory property for the debootstrap
action is suite.

Currently not specifying Mirror and/or Components results in a faulty
sources.list. This patch adds default values for the Mirror and
Components properties fixing the issue.

Signed-off-by: Peter Senna Tschudin <peter.senna@collabora.com>