### PR TITLE
debootstrap_action: add defaults for Mirror and Components

### DIFF
--- a/actions/debootstrap_action.go
+++ b/actions/debootstrap_action.go
@@ -21,10 +21,13 @@ Optional properties:
 - check-gpg -- verify GPG signatures on Release files, true by default
 
 - mirror -- URL with Debian-compatible repository
+ If no mirror is specified debos will use http://deb.debian.org/debian as default.
 
 - variant -- name of the bootstrap script variant to use
 
 - components -- list of components to use for packages selection.
+ If no components are specified debos will use main as default.
+
 Example:
  components: [ main, contrib ]
 
@@ -64,8 +67,12 @@ func NewDebootstrapAction() *DebootstrapAction {
 	d.MergedUsr = true
 	// Be secure by default
 	d.CheckGpg = true
-	return &d
+	// Use main as default component
+	d.Components = []string {"main"}
+	// Set generic default mirror
+	d.Mirror = "http://deb.debian.org/debian"
 
+	return &d
 }
 
 func (d *DebootstrapAction) RunSecondStage(context debos.DebosContext) error {


### PR DESCRIPTION
debos creates a sources.list file based on Mirror and Components from
the specification. However the only mandatory property for the
debootstrap action is suite.

Currently not specifying Mirror and/or Components results in a faulty
sources.list. This patch adds default values for the Mirror and
Components properties fixing the issue. It also document the defaults.

Signed-off-by: Peter Senna Tschudin <peter.senna@collabora.com>