### PR TITLE
docker: add basic docker support

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -29,7 +29,10 @@ RUN apt-get update && \
     ca-certificates \
     systemd-container \
     binfmt-support \
-    patch \
+    parted \
+    dosfstools \
+    e2fsprogs \
+    bmap-tools \
     # fakemachine runtime dependencies
     qemu-system-x86 \
     qemu-user-static \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,7 +14,6 @@ RUN apt-get update && \
 
 RUN go get -d github.com/go-debos/debos/cmd/debos
 WORKDIR /go/src/github.com/go-debos/debos/
-# RUN dep ensure
 RUN GOOS=linux go build -a cmd/debos/debos.go
 
 ### second stage - runner ###

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -47,7 +47,8 @@ RUN apt-get update && \
 # provide 1.0.100.
 RUN printf "deb http://httpredir.debian.org/debian stretch-backports main \ndeb-src http://httpredir.debian.org/debian stretch-backports main" > /etc/apt/sources.list.d/backports.list && \
     apt-get update && \
-    apt-get -t stretch-backports install -y debootstrap && \
+    apt-get -t stretch-backports install -y --no-install-recommends \
+    debootstrap && \
     rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /go/src/github.com/go-debos/debos/debos /usr/bin/debos

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,53 @@
+### first stage - builder ###
+FROM golang:1.10 as builder
+
+MAINTAINER Maciej Pijanowski <maciej.pijanowski@3mdeb.com>
+
+ENV HOME=/scratch
+
+# install debos build dependencies
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+    libglib2.0-dev \
+    libostree-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN go get -d github.com/go-debos/debos/cmd/debos
+WORKDIR /go/src/github.com/go-debos/debos/
+# RUN dep ensure
+RUN GOOS=linux go build -a cmd/debos/debos.go
+
+### second stage - runner ###
+FROM debian:stretch-slim as runner
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+# debos runtime dependencies
+# ca-certificates is required to validate HTTPS certificates when getting debootstrap release file
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+    libostree-1-1 \
+    ca-certificates \
+    systemd-container \
+    binfmt-support \
+    patch \
+    # fakemachine runtime dependencies
+    qemu-system-x86 \
+    qemu-user-static \
+    busybox \
+    linux-image-amd64 \
+    systemd \
+    dbus \
+    && rm -rf /var/lib/apt/lists/*
+
+# Bug description: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=806780
+# It was fixed in debootstrap 1.0.96 while Stretch provides 1.0.89. Backports
+# provide 1.0.100.
+RUN printf "deb http://httpredir.debian.org/debian stretch-backports main non-free\ndeb-src http://httpredir.debian.org/debian stretch-backports main non-free" > /etc/apt/sources.list.d/backports.list && \
+    apt-get update && \
+    apt-get -t stretch-backports install -y debootstrap && \
+    rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /go/src/github.com/go-debos/debos/debos /usr/bin/debos
+
+WORKDIR /root

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -43,7 +43,7 @@ RUN apt-get update && \
 # Bug description: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=806780
 # It was fixed in debootstrap 1.0.96 while Stretch provides 1.0.89. Backports
 # provide 1.0.100.
-RUN printf "deb http://httpredir.debian.org/debian stretch-backports main non-free\ndeb-src http://httpredir.debian.org/debian stretch-backports main non-free" > /etc/apt/sources.list.d/backports.list && \
+RUN printf "deb http://httpredir.debian.org/debian stretch-backports main \ndeb-src http://httpredir.debian.org/debian stretch-backports main" > /etc/apt/sources.list.d/backports.list && \
     apt-get update && \
     apt-get -t stretch-backports install -y debootstrap && \
     rm -rf /var/lib/apt/lists/*

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,22 @@
+Building
+--------
+
+```
+./build.sh
+```
+
+Prerequisites
+-------------
+
+* `binfmt_misc` module loaded on the host machine:
+
+```
+modprobe binfmt_misc
+```
+
+Running
+-------
+
+```
+./run.sh DEBOS_PARAMETERS
+```

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+docker build -t debos .

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+docker run --rm \
+	-it \
+	--privileged \
+	-v ${PWD}:/root \
+	debos \
+	/bin/bash -c "debos $*"

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
 
-docker run --rm \
-	-it \
-	--privileged \
-	-v ${PWD}:/root \
-	debos \
-	/bin/bash -c "debos $*"
+docker run --rm -it \
+    -u $(id -u) \
+    --device /dev/kvm \
+    --group-add=$(getent group kvm | cut -d : -f 3) \
+    -v ${PWD}:/root \
+    debos \
+    /bin/bash -c "debos $*"


### PR DESCRIPTION
Signed-off-by: Maciej Pijanowski <maciej.pijanowski@3mdeb.com>

The problem with building for non-host arch as described in the:
https://github.com/go-debos/debos/issues/9 was resolved. Basic
arm64 example image building was tested on the Ubuntu 18.04.
This may enable more users to take advantage of the debos, as
using it on non-Debian distros seems either impossible or not
trivial.