### PR TITLE
debootstrap: Explicitly disable merged /usr if not requested

### DIFF
--- a/actions/debootstrap_action.go
+++ b/actions/debootstrap_action.go
@@ -99,6 +99,8 @@ func (d *DebootstrapAction) Run(context *debos.DebosContext) error {
 
 	if d.MergedUsr {
 		cmdline = append(cmdline, "--merged-usr")
+	} else {
+		cmdline = append(cmdline, "--no-merged-usr")
 	}
 
 	if !d.CheckGpg {


### PR DESCRIPTION
Merged /usr is the default since debootstrap 1.0.102.

This change makes debos require debootstrap 1.0.83 or later.

Fixes: #115