### PR TITLE
Pass through http_proxy, etc. from caller's environment

### DIFF
--- a/cmd/debos/debos.go
+++ b/cmd/debos/debos.go
@@ -60,6 +60,10 @@ func main() {
 		}
 	}
 
+	for k, v := range options.SetEnv {
+		os.Setenv(k, v)
+	}
+
 	if len(args) != 1 {
 		log.Println("No recipe given!")
 		exitcode = 1
@@ -168,6 +172,23 @@ func main() {
 
 		for k, v := range options.SetEnv {
 			args = append(args, "--setenv", fmt.Sprintf("%s:\"%s\"", k, v))
+		}
+
+		e := os.Getenv("ftp_proxy")
+		if e != "" {
+			args = append(args, "--setenv", fmt.Sprintf("%s:\"%s\"", "ftp_proxy", e))
+		}
+		e = os.Getenv("http_proxy")
+		if e != "" {
+			args = append(args, "--setenv", fmt.Sprintf("%s:\"%s\"", "http_proxy", e))
+		}
+		e = os.Getenv("https_proxy")
+		if e != "" {
+			args = append(args, "--setenv", fmt.Sprintf("%s:\"%s\"", "https_proxy", e))
+		}
+		e = os.Getenv("no_proxy")
+		if e != "" {
+			args = append(args, "--setenv", fmt.Sprintf("%s:\"%s\"", "no_proxy", e))
 		}
 
 		m.AddVolume(context.RecipeDir)

--- a/cmd/debos/debos.go
+++ b/cmd/debos/debos.go
@@ -31,6 +31,7 @@ func main() {
 		ArtifactDir   string            `long:"artifactdir" description:"Directory for packed archives and ostree repositories (default: current directory)"`
 		InternalImage string            `long:"internal-image" hidden:"true"`
 		TemplateVars  map[string]string `short:"t" long:"template-var" description:"Template variables (use -t VARIABLE:VALUE syntax)"`
+		SetEnv        map[string]string `long:"setenv" description:"Set environment variables (use --setenv VARIABLE:VALUE syntax)"`
 		DebugShell    bool              `long:"debug-shell" description:"Fall into interactive shell on error"`
 		Shell         string            `short:"s" long:"shell" description:"Redefine interactive shell binary (default: bash)" optionsl:"" default:"/bin/bash"`
 		ScratchSize   string            `long:"scratchsize" description:"Size of disk backed scratch space"`
@@ -163,6 +164,10 @@ func main() {
 
 		for k, v := range options.TemplateVars {
 			args = append(args, "--template-var", fmt.Sprintf("%s:\"%s\"", k, v))
+		}
+
+		for k, v := range options.SetEnv {
+			args = append(args, "--setenv", fmt.Sprintf("%s:\"%s\"", k, v))
 		}
 
 		m.AddVolume(context.RecipeDir)

--- a/commands.go
+++ b/commands.go
@@ -69,6 +69,11 @@ func (w *commandWrapper) flush() {
 func NewChrootCommandForContext(context DebosContext) Command {
 	c := Command{Architecture: context.Architecture, Chroot: context.Rootdir, ChrootMethod: CHROOT_METHOD_NSPAWN}
 
+	c.InheritEnv("ftp_proxy")
+	c.InheritEnv("http_proxy")
+	c.InheritEnv("https_proxy")
+	c.InheritEnv("no_proxy")
+
 	if context.Image != "" {
 		path, err := RealPath(context.Image)
 		if err == nil {
@@ -96,6 +101,13 @@ func (cmd *Command) AddEnv(env string) {
 
 func (cmd *Command) AddEnvKey(key, value string) {
 	cmd.extraEnv = append(cmd.extraEnv, fmt.Sprintf("%s=%s", key, value))
+}
+
+func (cmd *Command) InheritEnv(key string) {
+	value := os.Getenv(key)
+	if value != "" {
+		cmd.AddEnvKey(key, value)
+	}
 }
 
 func (cmd *Command) AddBindMount(source, target string) {


### PR DESCRIPTION
This allows images to be built using a caching proxy like apt-cacher-ng, without its address having to be in the inputs or ending up hard-coded into the output.

As with all my PRs, this is probably not very idiomatic; I don't actually know Go.