### PR TITLE
Wip/sjoerd/sync no fakemachine mode

### DIFF
--- a/actions/raw_action.go
+++ b/actions/raw_action.go
@@ -116,6 +116,7 @@ func (raw *RawAction) Run(context *debos.DebosContext) error {
 	if err != nil {
 		return fmt.Errorf("Failed to open %s: %v", devicePath, err)
 	}
+	defer target.Close()
 
 	offset, err := strconv.ParseInt(raw.Offset, 0, 64)
 	if err != nil {
@@ -123,7 +124,12 @@ func (raw *RawAction) Run(context *debos.DebosContext) error {
 	}
 	bytes, err := target.WriteAt(content, offset)
 	if bytes != len(content) {
-		return errors.New("Couldn't write complete data")
+		return fmt.Errorf("Couldn't write complete data %v", err)
+	}
+
+	err = target.Sync()
+	if err != nil {
+		return fmt.Errorf("Couldn't sync content %v", err)
 	}
 
 	return nil


### PR DESCRIPTION
When building without fakemachine we've seen some issues where not all data was correctly flushed (or synced) into the image file before the post-processing actions ran. This caused issues with e.g. invalid checksums as well as bootloaders not being correctly on the image. The issues should be resolved with the various fixes in this PR