### PR TITLE
Exclude /dev's contents from `pack` command.

### DIFF
--- a/actions/pack_action.go
+++ b/actions/pack_action.go
@@ -35,5 +35,10 @@ func (pf *PackAction) Run(context *debos.DebosContext) error {
 	outfile := path.Join(context.Artifactdir, pf.File)
 
 	log.Printf("Compression to %s\n", outfile)
-	return debos.Command{}.Run("Packing", "tar", "czf", outfile, "-C", context.Rootdir, ".")
+	return debos.Command{}.Run(
+		"Packing",
+		"tar", "czf", outfile,
+		"--exclude", "./dev/*",
+		"-C", context.Rootdir,
+		".")
 }


### PR DESCRIPTION
Changes the `tar` invocation used by `pack` to exclude the contents of
the `./dev` subtree. In the fakemachine / chroot, these are devices
(`urandom` etc) that aren't actually packable- or rather, aren't
unpackable.

Fixes go-debos/debos#129.