### PR TITLE
filesystem_deploy_action: add option for kernel parameters

### DIFF
--- a/actions/filesystem_deploy_action.go
+++ b/actions/filesystem_deploy_action.go
@@ -8,6 +8,7 @@ Yaml syntax:
  - action: filesystem-deploy
    setup-fstab: bool
    setup-kernel-cmdline: bool
+   append-kernel-cmdline: arguments
 
 Optional properties:
 
@@ -16,6 +17,8 @@ by 'image-partition' action. By default is 'true'.
 
 - setup-kernel-cmdline -- add location of root partition to '/etc/kernel/cmdline'
 file on target image. By default is 'true'.
+
+- append-kernel-cmdline -- additional kernel command line arguments passed to kernel.
 */
 package actions
 
@@ -33,9 +36,10 @@ import (
 )
 
 type FilesystemDeployAction struct {
-	debos.BaseAction   `yaml:",inline"`
-	SetupFSTab         bool `yaml:"setup-fstab"`
-	SetupKernelCmdline bool `yaml:"setup-kernel-cmdline"`
+	debos.BaseAction    `yaml:",inline"`
+	SetupFSTab          bool   `yaml:"setup-fstab"`
+	SetupKernelCmdline  bool   `yaml:"setup-kernel-cmdline"`
+	AppendKernelCmdline string `yaml:"append-kernel-cmdline"`
 }
 
 func NewFilesystemDeployAction() *FilesystemDeployAction {
@@ -75,6 +79,8 @@ func (fd *FilesystemDeployAction) setupFSTab(context *debos.DebosContext) error 
 }
 
 func (fd *FilesystemDeployAction) setupKernelCmdline(context *debos.DebosContext) error {
+	var cmdline []string
+
 	log.Print("Setting up /etc/kernel/cmdline")
 
 	err := os.MkdirAll(path.Join(context.Rootdir, "etc", "kernel"), 0755)
@@ -89,11 +95,14 @@ func (fd *FilesystemDeployAction) setupKernelCmdline(context *debos.DebosContext
 		log.Fatalf("Couldn't open kernel cmdline: %v", err)
 	}
 
-	cmdline := fmt.Sprintf("%s %s\n",
-		strings.TrimSpace(string(current)),
-		context.ImageKernelRoot)
+	cmdline = append(cmdline, strings.TrimSpace(string(current)))
+	cmdline = append(cmdline, context.ImageKernelRoot)
 
-	_, err = f.WriteString(cmdline)
+	if fd.AppendKernelCmdline != "" {
+		cmdline = append(cmdline, fd.AppendKernelCmdline)
+	}
+
+	_, err = f.WriteString(strings.Join(cmdline, " ") + "\n")
 	if err != nil {
 		return fmt.Errorf("Couldn't write kernel/cmdline: %v", err)
 	}


### PR DESCRIPTION
Additional option 'append-kernel-cmdline' as we have for
'ostree-deploy' allows to fill `/etc/kernel/cmdline` config
with custom boot parameters.

Signed-off-by: Denis Pynkin <denis.pynkin@collabora.com>