### PR TITLE
Fix debootstrap failed with multiple components

### DIFF
--- a/actions/debootstrap_action.go
+++ b/actions/debootstrap_action.go
@@ -81,11 +81,6 @@ func (d *DebootstrapAction) RunSecondStage(context debos.DebosContext) error {
 		"--no-check-gpg",
 		"--second-stage"}
 
-	if d.Components != nil {
-		s := strings.Join(d.Components, ",")
-		cmdline = append(cmdline, fmt.Sprintf("--components=%s", s))
-	}
-
 	c := debos.NewChrootCommandForContext(context)
 	// Can't use nspawn for debootstrap as it wants to create device nodes
 	c.ChrootMethod = debos.CHROOT_METHOD_CHROOT


### PR DESCRIPTION
When multiple components are set for debootstrap action (like in README
simple example), image creation fails with following error:
2019/01/22 17:12:56 debootstrap.log | /debootstrap/debootstrap: 1363: /debootstrap/debootstrap: cannot open //var/lib/apt/lists/debootstrap.invalid_dists_sid_main|non-free_binary-arm64_Packages: No such file
2019/01/22 17:12:56 Action `debootstrap` failed at stage Run, error: exit status 2

The main and non-free component names are merged in
debootstrap.invalid_dists_sid_main|non-free_binary-arm64_Packages filename.

2nd stage of debootstrap does not need --components option.

Signed-off-by: Frédéric Danis <frederic.danis@collabora.com>