### PR TITLE
image-partition: add `fsck` flag

### DIFF
--- a/actions/image_partition_action.go
+++ b/actions/image_partition_action.go
@@ -82,6 +82,7 @@ should be mounted.
 Optional properties:
 
 - options -- list of options to be added to appropriate entry in fstab file.
+
 - buildtime -- if set to true then the mountpoint only used during the debos run.
 No entry in `/etc/fstab' will be created.
 The mountpoints directory will be removed from the image, so it is recommended


### PR DESCRIPTION
Enable filesystems check by default by setting `fs_passno` in fstab.
Allow to disable filesystem check on partition by setting flag `fsck`
to `false`.

Signed-off-by: Denis Pynkin <denis.pynkin@collabora.com>