### PR TITLE
cmd: Fix slice of structs dump

### DIFF
--- a/cmd/debos/debos.go
+++ b/cmd/debos/debos.go
@@ -111,10 +111,10 @@ func DumpActionFields(iface interface{}, depth int) {
 			case reflect.Slice:
 				s := reflect.ValueOf(f.Interface())
 				if s.Len() > 0 && s.Index(0).Kind() == reflect.Struct {
-					log.Printf("    %s:\n", entries.Type().Field(i).Name)
+					log.Printf("%s  %s:\n", tab, entries.Type().Field(i).Name)
 					for j := 0; j < s.Len(); j++ {
 						if s.Index(j).Kind() == reflect.Struct {
-							log.Printf("%s  { %s }", tab, DumpActionStruct(s.Index(j).Interface()))
+							log.Printf("%s    { %s }", tab, DumpActionStruct(s.Index(j).Interface()))
 						}
 					}
 				} else {


### PR DESCRIPTION
Slice of structs dump are not correctly aligned in case of recursive calls.
Use correct numbers of spaces, like for other type dumps.

Signed-off-by: Frédéric Danis <frederic.danis@collabora.com>