### PR TITLE
doc/examples: Actually use suite variable

### DIFF
--- a/doc/examples/example.yaml
+++ b/doc/examples/example.yaml
@@ -1,12 +1,12 @@
 {{- $architecture := or .architecture "arm64" -}}
-{{- $suite := or .suite "stretch" -}}
+{{- $suite := or .suite "buster" -}}
 {{ $image := or .image (printf "debian-%s-%s.tgz" $suite $architecture) }}
 
 architecture: {{ $architecture }}
 
 actions:
   - action: debootstrap
-    suite: "buster"
+    suite: {{ $suite }}
     components:
       - main
       - contrib


### PR DESCRIPTION
We declared the suite variable (defaulting to stretch), but only used it
for the filename and not for building the OS, which took a hardcoded
suite name.

Use the suite variable in OS building, changing the default to buster to
match the previous hard-coding.

Signed-off-by: Daniel Stone <daniels@collabora.com>