### PR TITLE
docker: Container should be used as an executable

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,15 @@ Some of the actions provided by debos to customize and produce images are:
 A full syntax description of all the debos actions can be found at:
 https://godoc.org/github.com/go-debos/debos/actions
 
+## Installation (Docker container)
+
+Official debos container is available:
+```
+docker pull godebos/debos
+```
+
+See [docker/README.md](https://github.com/go-debos/debos/blob/master/docker/README.md) for usage.
+
 ## Installation (under Debian)
 
     sudo apt install golang git libglib2.0-dev libostree-dev qemu-system-x86 \

--- a/docker/README.md
+++ b/docker/README.md
@@ -12,6 +12,8 @@ Debos needs virtualization to be enabled on the host and shared with the contain
 Check that `kvm` is enabled and writable by the user running the docker container by running ```ls /dev/kvm```
 
 ## Usage
+/!\ This container should be used as an executable, i.e. there is no need to add `debos` after `godebos/debos`.
+
 To build `recipe.yaml`:
 ```
 cd <PATH_TO_RECIPE_DIR>


### PR DESCRIPTION
The usage of the container as an executable does not seems to be
straightforward.
Add a warning in docker/README.md and add container installation reference
in main README.md.

Signed-off-by: Frédéric Danis <frederic.danis@collabora.com>