### PR TITLE
commands: fix chroot method comments

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -13,8 +13,8 @@ import (
 type ChrootEnterMethod int
 
 const (
-	CHROOT_METHOD_NONE   = iota // use nspawn to create the chroot environment
-	CHROOT_METHOD_NSPAWN        // No chroot in use
+	CHROOT_METHOD_NONE   = iota // No chroot in use
+	CHROOT_METHOD_NSPAWN        // use nspawn to create the chroot environment
 	CHROOT_METHOD_CHROOT        // use chroot to create the chroot environment
 )
 


### PR DESCRIPTION
It looks like the comments for CHROOT_METHOD_NSPAWN and
CHROOT_METHOD_NONE have been swapped

Signed-off-by: Daniel Sangorrin <daniel.sangorrin@toshiba.co.jp>