### PR TITLE
pack,unpack: Save and restore xattrs and file capabilities in tarballs

### DIFF
--- a/TODO
+++ b/TODO
@@ -41,8 +41,6 @@ TODO
 * Make actions using (host) commands check their existance early
 
 
-* Ensure we copy xattrs?
-
 * Fix race in qemu-helper (if qemu-user-static gets installed in the system
   chroot  things will get confused)
 

--- a/actions/pack_action.go
+++ b/actions/pack_action.go
@@ -35,5 +35,7 @@ func (pf *PackAction) Run(context *debos.DebosContext) error {
 	outfile := path.Join(context.Artifactdir, pf.File)
 
 	log.Printf("Compressing to %s\n", outfile)
-	return debos.Command{}.Run("Packing", "tar", "czf", outfile, "-C", context.Rootdir, ".")
+	return debos.Command{}.Run("Packing", "tar", "czf", outfile,
+		"--xattrs", "--xattrs-include=*.*",
+		"-C", context.Rootdir, ".")
 }

--- a/archiver.go
+++ b/archiver.go
@@ -99,6 +99,8 @@ func (tar *ArchiveTar) Unpack(destination string) error {
 	}
 	command = append(command, "-C", destination)
 	command = append(command, "-x")
+	command = append(command, "--xattrs")
+	command = append(command, "--xattrs-include=*.*")
 
 	if compression, ok := tar.options["tarcompression"]; ok {
 		if unpackTarOpt := tarOptions(compression.(string)); len(unpackTarOpt) > 0 {


### PR DESCRIPTION
Add options to `tar` to tell it to save and restore extended attributes:
    
* `--xattr`: enable extended attributes support
* `--xattrs-include=*.*`: tell `tar` to include every extended attribute
  since by default `tar` only stores attributes in the `user.*` namespace
    
This fixes the `pack` and `unpack` actions when dealing with tools like
`ping` which on modern distributions have been switched to use file
capabilities to do privileged operations without being setuid, as they are
based on extended attributes.
    
This relies on `tar` being GNU Tar >= 1.27, released in 2013 and shipped since
Debian Jessie.

Tested with the recipe below:
```
architecture: amd64

actions:
  - action: run
    description: Create test file
    chroot: false
    command: touch "${ROOTDIR}/testfile"

  - action: run
    description: Set file capabilities on test file
    chroot: false
    command: setcap cap_sys_pacct=p "${ROOTDIR}/testfile"

  - action: pack
    file: testpack.tar.gz

  - action: run
    description: Clean up test file
    chroot: false
    command: rm "${ROOTDIR}/testfile"

  - action: unpack
    file: testpack.tar.gz

  - action: run
    description: Dump the unpacked file capabilities
    chroot: false
    command: getcap "${ROOTDIR}/testfile"

  - action: run
    description: Check that the file capabilities are set
    chroot: false
    command: getcap "${ROOTDIR}/testfile" | grep -c cap_sys_pacct+p
```