### PR TITLE
Always create fat32 filesystem on vfat partitions

### DIFF
--- a/actions/image_partition_action.go
+++ b/actions/image_partition_action.go
@@ -264,7 +264,7 @@ func (i ImagePartitionAction) formatPartition(p *Partition, context debos.DebosC
 	cmdline := []string{}
 	switch p.FS {
 	case "vfat":
-		cmdline = append(cmdline, "mkfs.vfat", "-n", p.Name)
+		cmdline = append(cmdline, "mkfs.vfat", "-F32", "-n", p.Name)
 	case "btrfs":
 		// Force formatting to prevent failure in case if partition was formatted already
 		cmdline = append(cmdline, "mkfs.btrfs", "-L", p.Name, "-f")


### PR DESCRIPTION
As described in mkfs.vfat(8) the default is to create either fat12,
fat16 or fat32 based on partition size.
This can come as an unlucky surprise whem used with something that has a
buggy fat implementation which only works with fat32, eg. some
revisions of the raspberry pi boot rom.
For more info see bottom of ("Troubleshooting"):
https://www.raspberrypi.org/documentation/hardware/computemodule/cm-emmc-flashing.md

This commit changes so we explicitly say use fat32 always, as fat12 and
fat16 are likely rare enought that noone really wants to use them when
creating a new image. This might be worthy of a release notes news entry
in case someone wonders why their image suddenly changed using the same
unmodified recipe with different versions of debos.

Fixes: #169