### PR TITLE
actions: add pkglist action

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Some of the actions provided by debos to customize and produce images are:
 * ostree-deploy: deploy an OSTree branch to the image
 * overlay: do a recursive copy of directories or files to the target filesystem
 * pack: create a tarball with the target filesystem
+* pkglist: export a Debian package list to the artifacts directory
 * raw: directly write a file to the output image at a given offset
 * recipe: includes the recipe actions at the given path
 * run: allows to run a command or script in the filesystem or in the host

--- a/actions/pkglist_action.go
+++ b/actions/pkglist_action.go
@@ -1,0 +1,63 @@
+/*
+Pkglist action
+
+Export a Debian package list to the artifacts directory
+
+Yaml syntax:
+ - action: pkglist
+   file: pkglist.txt
+
+Optional properties:
+
+- file -- name of the output file, relative to the artifact directory.
+If empty, it defaults to 'pkglist.txt'.
+*/
+package actions
+
+import (
+	"os"
+	"path"
+
+	"github.com/go-debos/debos"
+)
+
+type PkglistAction struct {
+	debos.BaseAction `yaml:",inline"`
+	File             string
+}
+
+func (pkglist *PkglistAction) Run(context *debos.DebosContext) error {
+	pkglist.LogStart()
+	var cmdline []string
+	var cmd debos.Command
+	var err error
+
+	// get the package list inside chroot
+	cmd = debos.NewChrootCommandForContext(*context)
+	cmdline = []string{"dpkg --list > /output.txt"}
+	cmdline = append([]string{"sh", "-c"}, cmdline...)
+
+	err = cmd.Run("pkglist", cmdline...)
+	if err != nil {
+		return err
+	}
+
+	// move it to artifacts folder outside chroot
+	src := path.Join(context.Rootdir, "output.txt")
+	if pkglist.File == "" {
+		pkglist.File = "pkglist.txt"
+	}
+	dest := path.Join(context.Artifactdir, pkglist.File)
+
+	err = debos.CopyFile(src, dest, 0644)
+	if err != nil {
+		return err
+	}
+
+	err = os.Remove(src)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/actions/recipe.go
+++ b/actions/recipe.go
@@ -55,6 +55,8 @@ Supported actions
 
 - pack -- https://godoc.org/github.com/go-debos/debos/actions#hdr-Pack_Action
 
+- pkglist -- https://godoc.org/github.com/go-debos/debos/actions#hdr-Pkglist_Action
+
 - raw -- https://godoc.org/github.com/go-debos/debos/actions#hdr-Raw_Action
 
 - recipe -- https://godoc.org/github.com/go-debos/debos/actions#hdr-Recipe_Action
@@ -124,6 +126,8 @@ func (y *YamlAction) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		y.Action = &DownloadAction{}
 	case "recipe":
 		y.Action = &RecipeAction{}
+	case "pkglist":
+		y.Action = &PkglistAction{}
 	default:
 		return fmt.Errorf("Unknown action: %v", aux.Action)
 	}


### PR DESCRIPTION
When you use debos on a product you often need to export
a list of the packages installed. This can be done with
two Run actions, but having a new action makes it simpler.

Before:

  - action: run
    chroot: true
    command: dpkg --list > /output.txt

  - action: run
    chroot: false
    command: cp $ROOTDIR/output.txt $ARTIFACTDIR/

After:
  - action: pkglist
    file: output.txt <-- optional

Signed-off-by: Daniel Sangorrin <daniel.sangorrin@toshiba.co.jp>