### PR TITLE
ostree-deploy: fix umount error

### DIFF
--- a/actions/ostree_deploy_action.go
+++ b/actions/ostree_deploy_action.go
@@ -55,7 +55,6 @@ import (
 	"io"
 	"os"
 	"path"
-	"runtime"
 	"strings"
 
 	"github.com/go-debos/debos"
@@ -198,6 +197,11 @@ func (ot *OstreeDeployAction) Run(context *debos.DebosContext) error {
 		return err
 	}
 
-	runtime.GC()
+	/* libostree keeps some information, like repo lock file descriptor, in
+	 * thread specific variables. As GC can be run from another thread, it
+	 * may not been able to access this, preventing to free them correctly.
+	 * To prevent this, explicitly dereference libostree objects. */
+	dstRepo.Unref()
+	sysroot.Unref()
 	return nil
 }


### PR DESCRIPTION
Sometimes `umount` fails after `ostree-deploy` with following error:
```
2019/08/26 14:08:51 ==== Deploying ostree onto image ====
2019/08/26 14:08:57 ==== List files on ostreetestarmhf ====
2019/08/26 14:08:59 Warning: Failed to get unmount /: device or resource busy
2019/08/26 14:08:59 Unmount failure can cause images being incomplete!
```

`libostree` keeps some information, like _repo lock file descriptor_, in thread specific variables.
As _Go Garbage Collector_ can be run in a thread different from the one which created the `libostree` object, it may not been able to access the object thread specific variables, preventing to free them correctly.
To prevent this, explicitly dereference `libostree` objects.

Signed-off-by: Frédéric Danis <frederic.danis@collabora.com>