### PR TITLE
docker: Add unzip

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -72,6 +72,7 @@ RUN apt-get update && \
         qemu-user-static \
         systemd \
         systemd-container \
+        unzip \
         xz-utils && \
     rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
This makes the download action work when unpack is enabled and the downloaded file is of type zip.