### PR TITLE
Feature chroot support mounts

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -20,14 +20,19 @@ const (
 	CHROOT_METHOD_CHROOT        // use chroot to create the chroot environment
 )
 
+type BindMount struct {
+	Source string
+	Target string
+}
+
 type Command struct {
 	Architecture string            // Architecture of the chroot, nil if same as host
 	Dir          string            // Working dir to run command in
 	Chroot       string            // Run in the chroot at path
 	ChrootMethod ChrootEnterMethod // Method to enter the chroot
 
-	bindMounts []string /// Items to bind mount
-	extraEnv   []string // Extra environment variables to set
+	bindMounts []BindMount // Items to bind mount
+	extraEnv   []string  // Extra environment variables to set
 }
 
 type commandWrapper struct {
@@ -107,12 +112,14 @@ func (cmd *Command) AddEnvKey(key, value string) {
 }
 
 func (cmd *Command) AddBindMount(source, target string) {
-	var mount string
-	if target != "" {
-		mount = fmt.Sprintf("%s:%s", source, target)
+	var mount BindMount
+
+	if target == "" {
+		mount.Target = source
 	} else {
-		mount = source
+		mount.Target = target
 	}
+	mount.Source = source
 
 	cmd.bindMounts = append(cmd.bindMounts, mount)
 }
@@ -229,7 +236,7 @@ func (cmd Command) Run(label string, cmdline ...string) error {
 
 		}
 		for _, b := range cmd.bindMounts {
-			options = append(options, "--bind", b)
+			options = append(options, "--bind", fmt.Sprintf("%s:%s", b.Source, b.Target))
 
 		}
 		options = append(options, cmdline...)


### PR DESCRIPTION
In prepration to allow the user to choose the chroot/container method. Add mount/umount support to chroot.
The following example is using bind mounts to run scripts inside the chroot/nspawn environment.
```
action: run
script: foo.sh
```  