### PR TITLE
commands: do not touch /etc/localtime in chrooted calls

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -209,7 +209,9 @@ func (cmd Command) Run(label string, cmdline ...string) error {
 		options = append(options, cmdline...)
 	case CHROOT_METHOD_NSPAWN:
 		// We use own resolv.conf handling
-		options = append(options, "systemd-nspawn", "-q", "--resolv-conf=off", "-D", cmd.Chroot)
+		options = append(options, "systemd-nspawn", "-q")
+		options = append(options, "--resolv-conf=off")
+		options = append(options, "--timezone=off")
 		for _, e := range cmd.extraEnv {
 			options = append(options, "--setenv", e)
 
@@ -218,6 +220,7 @@ func (cmd Command) Run(label string, cmdline ...string) error {
 			options = append(options, "--bind", b)
 
 		}
+		options = append(options, "-D", cmd.Chroot)
 		options = append(options, cmdline...)
 	}
 


### PR DESCRIPTION
Added option `--timezone=off` for `systemd-nspawn` to leave the
file untouched during the chrooted calls.

Fixes: #180

Signed-off-by: Denis Pynkin <denis.pynkin@collabora.com>