### PR TITLE
docker: Add u-boot-tools package

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -73,6 +73,7 @@ RUN apt-get update && \
         qemu-user-static \
         systemd \
         systemd-container \
+	u-boot-tools \
         unzip \
         xz-utils && \
     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Add the u-boot-tools package to be able to use binaries such as
mkimage in debos' recipes.

Signed-off-by: Mylène Josserand <mylene.josserand@collabora.com>