### PR TITLE
action: run: expose context.ImageMntDir as $IMAGEMNTDIR

### DIFF
--- a/actions/run_action.go
+++ b/actions/run_action.go
@@ -2,7 +2,8 @@
 Run Action
 
 Allows to run any available command or script in the filesystem or
-in host environment.
+in build process host environment: specifically inside the fakemachine created
+by Debos.
 
 Yaml syntax:
  - action: run
@@ -24,8 +25,10 @@ Optional properties:
 - chroot -- run script or command in target filesystem if set to true.
 Otherwise the command or script is executed within the build process, with
 access to the filesystem ($ROOTDIR), the image if any ($IMAGE), the
-recipe directory ($RECIPEDIR) and the artifact directory ($ARTIFACTDIR).
-In both cases it is run with root privileges.
+recipe directory ($RECIPEDIR), the artifact directory ($ARTIFACTDIR) and the
+directory where the image is mounted ($IMAGEMNTDIR).
+In both cases it is run with root privileges. If unset, chroot is set to false and
+the command or script is run in the host environment.
 
 - label -- if non-empty, this string is used to label output. If empty,
 a label is derived from the command or script.
@@ -120,6 +123,9 @@ func (run *RunAction) doRun(context debos.DebosContext) error {
 			cmd.AddEnvKey("ROOTDIR", context.Rootdir)
 			cmd.AddEnvKey("RECIPEDIR", context.RecipeDir)
 			cmd.AddEnvKey("ARTIFACTDIR", context.Artifactdir)
+			if context.ImageMntDir != "" {
+				cmd.AddEnvKey("IMAGEMNTDIR", context.ImageMntDir)
+			}
 		}
 		if context.Image != "" {
 			cmd.AddEnvKey("IMAGE", context.Image)


### PR DESCRIPTION
When a command is ran using `action: run` some environment variables are exposed to the script.

`$ROOTDIR` is set to `context.Rootdir=/scratch/root` which is a temporary
directory meant to hold the rootfs until `action: filesystem-deploy` is ran, which
copies from `context.Rootdir` to `context.ImageMntDir`. After the filesystem is
deployed, `context.Rootdir` is set to `context.ImageMntDir`.

The mount points defined under action: image-partition are mounted under
`context.ImageMntDir`, so if the filesystem is never deployed, there is no
(simple) way for the script to know where the images are mounted to.

So, expose `context.ImageMntDir` to the script as `$IMAGEMNTDIR` so the recipe
can know where the image is mounted.

Resolves: #204

Signed-off-by: Christopher Obbard <chris.obbard@collabora.com>