### PR TITLE
docs: action: filesystem-deploy: clarify what happens after deploy

### DIFF
--- a/actions/filesystem_deploy_action.go
+++ b/actions/filesystem_deploy_action.go
@@ -1,8 +1,13 @@
 /*
 FilesystemDeploy Action
 
-Deploy prepared root filesystem to output image. This action requires
-'image-partition' action to be executed before it.
+Deploy prepared root filesystem to output image by copying the files from the
+temporary scratch directory to the mounted image and optionally creates various
+configuration files for the image: '/etc/fstab' and '/etc/kernel/cmdline'. This
+action requires 'image-partition' action to be executed before it.
+
+After this action has ran, subsequent actions are executed on the mounted output
+image.
 
 Yaml syntax:
  - action: filesystem-deploy


### PR DESCRIPTION
All the filesystem-deploy action does is copy the contents from scratch into the
mounted image, then all actions after that refer to the image rather than the
scratch space. Be clearer.

Resolves: #175

Signed-off-by: Christopher Obbard <chris.obbard@collabora.com>