### PR TITLE
actions/image_partition: do not return error if removing buildtime mountpoint with a read-only parent

### DIFF
--- a/actions/image_partition_action.go
+++ b/actions/image_partition_action.go
@@ -449,6 +449,11 @@ func (i ImagePartitionAction) Cleanup(context *debos.DebosContext) error {
 		if m.Buildtime == true {
 			if err = os.Remove(mntpath); err != nil {
 				log.Printf("Failed to remove temporary mount point %s: %s", m.Mountpoint, err)
+
+				if err.(*os.PathError).Err.Error() == "read-only file system" {
+					continue
+				}
+
 				return err
 			}
 		}


### PR DESCRIPTION
Returning an error in this function causes the rest of the cleanup operation to
not be executed; so in this case downgrading an error to remove the mountpoint
from the read-only filesystem to a warning is wise.

Resolves: #206

Signed-off-by: Christopher Obbard <chris.obbard@collabora.com>