### PR TITLE
actions/run: Improve run action verification

### DIFF
--- a/actions/run_action.go
+++ b/actions/run_action.go
@@ -63,6 +63,10 @@ func (run *RunAction) Verify(context *debos.DebosContext) error {
 	if run.PostProcess && run.Chroot {
 		return errors.New("Cannot run postprocessing in the chroot")
 	}
+
+	if run.Script == "" && run.Command == "" {
+		return errors.New("Script and Command both cannot be empty")
+	}
 	return nil
 }
 


### PR DESCRIPTION
For the run action, debos does not complain even if both "script" and
"command" are empty which can occur due to a typo or accidentally
missing the tag.

As the documentation already mentions that one of "script" or
"command" is mandatory for the run action, let's detect the invalid
scenario and complain to the user instead of silently continuing.

Signed-off-by: Punit Agrawal <punit1.agrawal@toshiba.co.jp>