### PR TITLE
actions: image_partition: add F2FS support

### DIFF
--- a/actions/image_partition_action.go
+++ b/actions/image_partition_action.go
@@ -293,6 +293,11 @@ func (i ImagePartitionAction) formatPartition(p *Partition, context debos.DebosC
 		if len(p.Features) > 0 {
 			cmdline = append(cmdline, "-O", strings.Join(p.Features, ","))
 		}
+	case "f2fs":
+		cmdline = append(cmdline, "mkfs.f2fs", "-l", p.Name)
+		if len(p.Features) > 0 {
+			cmdline = append(cmdline, "-O", strings.Join(p.Features, ","))
+		}
 	case "hfs":
 		cmdline = append(cmdline, "mkfs.hfs", "-h", "-v", p.Name)
 	case "hfsplus":
@@ -398,6 +403,7 @@ func (i ImagePartitionAction) Run(context *debos.DebosContext) error {
 			command = append(command, "fat32")
 		case "hfsplus":
 			command = append(command, "hfs+")
+		case "f2fs":
 		case "none":
 		default:
 			command = append(command, p.FS)


### PR DESCRIPTION
F2FS requires a few tweaks to be usable within debos:
  * its command-line option for setting the fs label is different from
    other mkfs utils
  * parted doesn't recognize "f2fs" as a valid filesystem, therefore it
    shouldn't appear on the command line

With these simple changes, it becomes possible to use F2FS partitions
with debos.