### PR TITLE
actions/apt_action: Add property 'update'

### DIFF
--- a/actions/recipe.go
+++ b/actions/recipe.go
@@ -107,7 +107,7 @@ func (y *YamlAction) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	case "run":
 		y.Action = &RunAction{}
 	case "apt":
-		y.Action = &AptAction{}
+		y.Action = NewAptAction()
 	case "ostree-commit":
 		y.Action = &OstreeCommitAction{}
 	case "ostree-deploy":


### PR DESCRIPTION
This property is a boolean value indicating if `apt update` will be run
before install package. Default value is 'true'.

Signed-off-by: Trung Do <trung1.dothanh@toshiba.co.jp>
Signed-off-by: Daniel Sangorrin <daniel.sangorrin@toshiba.co.jp>