### PR TITLE
action/debootstrap: use absolute paths for certificate and private-key

### DIFF
--- a/actions/debootstrap_action.go
+++ b/actions/debootstrap_action.go
@@ -134,11 +134,11 @@ func (d *DebootstrapAction) Run(context *debos.DebosContext) error {
 	}
 
 	if d.Certificate != "" {
-		cmdline = append(cmdline, fmt.Sprintf("--certificate=%s", d.Certificate))
+		cmdline = append(cmdline, fmt.Sprintf("--certificate=%s", path.Join(context.RecipeDir, d.Certificate)))
 	}
 
 	if d.PrivateKey != "" {
-		cmdline = append(cmdline, fmt.Sprintf("--private-key=%s", d.PrivateKey))
+		cmdline = append(cmdline, fmt.Sprintf("--private-key=%s", path.Join(context.RecipeDir, d.PrivateKey)))
 	}
 
 	if d.Components != nil {


### PR DESCRIPTION
Need to use absolute paths for certificate and private key to avoid
problems caused by incorrect current directory.

Signed-off-by: Denis Pynkin <denis.pynkin@collabora.com>