### PR TITLE
cmd: Don't print command-line parsing error twice

### DIFF
--- a/cmd/debos/debos.go
+++ b/cmd/debos/debos.go
@@ -101,7 +101,6 @@ func main() {
 		if ok && flagsErr.Type == flags.ErrHelp {
 			return
 		} else {
-			fmt.Printf("%v\n", flagsErr)
 			exitcode = 1
 			return
 		}


### PR DESCRIPTION
The command-line argument parsing library already prints any parsing
errors; there's no need to print the error again ourselves.

Signed-off-by: Christopher Obbard <chris.obbard@collabora.com>