### PR TITLE
docker: Add equivs package

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -67,6 +67,7 @@ RUN apt-get update && \
         debootstrap \
         dosfstools \
         e2fsprogs \
+        equivs \
         fdisk \
         f2fs-tools \
         gzip \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -79,7 +79,7 @@ RUN apt-get update && \
         qemu-user-static \
         systemd \
         systemd-container \
-	u-boot-tools \
+        u-boot-tools \
         unzip \
         xz-utils && \
     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
The equivs package is used to create dummy Debian packages which can
be useful in development to satisfy dependencies without installing the
real package. Note that this package is not the recommended way of
dealing with broken dependencies: a bug report should be filed instead.
