### PR TITLE
systemd-nspawn shall be called with option "--register=no" to prevent…

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -226,6 +226,7 @@ func (cmd Command) Run(label string, cmdline ...string) error {
 		options = append(options, "systemd-nspawn", "-q")
 		options = append(options, "--resolv-conf=off")
 		options = append(options, "--timezone=off")
+		options = append(options, "--register=no")
 		for _, e := range cmd.extraEnv {
 			options = append(options, "--setenv", e)
 


### PR DESCRIPTION
… error after debootstrap

After debootstrap the call of "debos" fails with message "Failed to register machine: Unit machine-root.scope already exists".
With the option "--register=no" this works fine. This change is derived from https://gitlab.collabora.com/smcv/flatdeb/-/merge_requests/6

Signed-off-by: mtt2hi <thomas.mittelstaedt@de.bosch.com>