### PR TITLE
docker: Add zip package

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -84,7 +84,8 @@ RUN apt-get update && \
         u-boot-tools \
         unzip \
         user-mode-linux \
-        xz-utils && \
+        xz-utils \
+        zip && \
     rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder $GOPATH/bin/debos /usr/local/bin/debos


### PR DESCRIPTION
Add the zip package to allow the cration of compressed zip archives.

Signed-off-by: Christopher Obbard <chris.obbard@collabora.com>