### PR TITLE
image-partition: Modify property 'fsuuid' to allow setting UUID

### DIFF
--- a/actions/image_partition_action.go
+++ b/actions/image_partition_action.go
@@ -90,7 +90,7 @@ for partition.
 checks in boot time. By default is set to `true` allowing checks on boot.
 
 - fsuuid -- file system UUID string. This option is only supported for btrfs,
-ext2, ext3, and ext4.
+ext2, ext3, ext4 and xfs.
 
 Yaml syntax for mount points:
 
@@ -327,6 +327,11 @@ func (i ImagePartitionAction) formatPartition(p *Partition, context debos.DebosC
 		cmdline = append(cmdline, "mkfs.hfsplus", "-s", "-v", p.Name)
 		// hfsx is case-insensitive hfs+, should be treated as "normal" hfs+ from now on
 		p.FS = "hfsplus"
+	case "xfs":
+		cmdline = append(cmdline, "mkfs.xfs", "-L", p.Name)
+		if len(p.FSUUID) > 0 {
+			cmdline = append(cmdline, "-m", "uuid="+p.FSUUID)
+		}
 	case "none":
 	default:
 		cmdline = append(cmdline, fmt.Sprintf("mkfs.%s", p.FS), "-L", p.Name)
@@ -608,7 +613,7 @@ func (i *ImagePartitionAction) Verify(context *debos.DebosContext) error {
 		}
 
 		if len(p.FSUUID) > 0 {
-			if p.FS == "btrfs" || p.FS == "ext2" || p.FS == "ext3" || p.FS == "ext4" {
+			if p.FS == "btrfs" || p.FS == "ext2" || p.FS == "ext3" || p.FS == "ext4" || p.FS == "xfs" {
 				_, err := uuid.Parse(p.FSUUID)
 				if err != nil {
 					return fmt.Errorf("Incorrect UUID %s", p.FSUUID)

--- a/actions/image_partition_action.go
+++ b/actions/image_partition_action.go
@@ -48,6 +48,7 @@ Yaml syntax for partitions:
 	   features: list of filesystem features
 	   flags: list of flags
 	   fsck: bool
+	   fsuuid: string
 
 Mandatory properties:
 
@@ -87,6 +88,9 @@ for partition.
 
 - fsck -- if set to `false` -- then set fs_passno (man fstab) to 0 meaning no filesystem
 checks in boot time. By default is set to `true` allowing checks on boot.
+
+- fsuuid -- file system UUID string. This option is only supported for btrfs,
+ext2, ext3, and ext4.
 
 Yaml syntax for mount points:
 
@@ -145,6 +149,7 @@ import (
 	"fmt"
 	"github.com/docker/go-units"
 	"github.com/go-debos/fakemachine"
+	"github.com/google/uuid"
 	"gopkg.in/freddierice/go-losetup.v1"
 	"log"
 	"os"
@@ -306,6 +311,9 @@ func (i ImagePartitionAction) formatPartition(p *Partition, context debos.DebosC
 		if len(p.Features) > 0 {
 			cmdline = append(cmdline, "-O", strings.Join(p.Features, ","))
 		}
+		if len(p.FSUUID) > 0 {
+			cmdline = append(cmdline, "-U", p.FSUUID)
+		}
 	case "f2fs":
 		cmdline = append(cmdline, "mkfs.f2fs", "-l", p.Name)
 		if len(p.Features) > 0 {
@@ -325,6 +333,11 @@ func (i ImagePartitionAction) formatPartition(p *Partition, context debos.DebosC
 		if len(p.Features) > 0 {
 			cmdline = append(cmdline, "-O", strings.Join(p.Features, ","))
 		}
+		if len(p.FSUUID) > 0 {
+			if p.FS == "ext2" || p.FS == "ext3" || p.FS == "ext4" {
+				cmdline = append(cmdline, "-U", p.FSUUID)
+			}
+		}
 	}
 
 	if len(cmdline) != 0 {
@@ -336,7 +349,7 @@ func (i ImagePartitionAction) formatPartition(p *Partition, context debos.DebosC
 		}
 	}
 
-	if p.FS != "none" {
+	if p.FS != "none" && p.FSUUID == "" {
 		uuid, err := exec.Command("blkid", "-o", "value", "-s", "UUID", "-p", "-c", "none", path).Output()
 		if err != nil {
 			return fmt.Errorf("Failed to get uuid: %s", err)
@@ -591,6 +604,17 @@ func (i *ImagePartitionAction) Verify(context *debos.DebosContext) error {
 		for j := idx + 1; j < len(i.Partitions); j++ {
 			if i.Partitions[j].Name == p.Name {
 				return fmt.Errorf("Partition %s already exists", p.Name)
+			}
+		}
+
+		if len(p.FSUUID) > 0 {
+			if p.FS == "btrfs" || p.FS == "ext2" || p.FS == "ext3" || p.FS == "ext4" {
+				_, err := uuid.Parse(p.FSUUID)
+				if err != nil {
+					return fmt.Errorf("Incorrect UUID %s", p.FSUUID)
+				}
+			} else {
+				return fmt.Errorf("Setting the UUID is not supported for filesystem %s", p.FS)
 			}
 		}
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -85,6 +85,7 @@ RUN apt-get update && \
         u-boot-tools \
         unzip \
         user-mode-linux \
+        xfsprogs \
         xz-utils \
         zip && \
     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Currently support setting UUID for btrfs, xfs, ext2, ext3, ext4 file system

Signed-off-by: Nguyen Thi Huong <huong4.nguyenthi@toshiba.co.jp>
Signed-off-by: Daniel Sangorrin <daniel.sangorrin@toshiba.co.jp>