### PR TITLE
docker: Manually register binfmts

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -91,6 +91,12 @@ RUN echo "deb http://deb.debian.org/debian experimental main" > /etc/apt/sources
         qemu-user-static && \
     rm -rf /var/lib/apt/lists/*
 
+# debian's qemu-user-static package no longer registers binfmts
+# if running inside a virtualmachine; dockerhub builds are inside a vm
+RUN for arch in aarch64 alpha arm armeb cris hexagon hppa m68k microblaze mips mips64 mips64el mipsel mipsn32 mipsn32el ppc ppc64 ppc64le riscv32 riscv64 s390x sh4 sh4eb sparc sparc32plus sparc64 xtensa xtensaeb; do \
+      update-binfmts --import qemu-$arch; \
+    done
+
 COPY --from=builder $GOPATH/bin/debos /usr/local/bin/debos
 
 ENTRYPOINT ["/usr/local/bin/debos"]


### PR DESCRIPTION
Debian's qemu-user-static package no longer registers binfmts on postinst
when running inside a virtualmachine; dockerhub builds are now built inside
a vm so the binfmts are not generated inside the docker container.

Fixes: 91af617bea07 ("docker: Install qemu-user-static 6.0 to fix segfault")

Signed-off-by: Christopher Obbard <chris.obbard@collabora.com>