### PR TITLE
actions: raw: Actually make offset optional

### DIFF
--- a/actions/raw_action.go
+++ b/actions/raw_action.go
@@ -118,10 +118,14 @@ func (raw *RawAction) Run(context *debos.DebosContext) error {
 	}
 	defer target.Close()
 
-	offset, err := strconv.ParseInt(raw.Offset, 0, 64)
-	if err != nil {
-		return fmt.Errorf("Couldn't parse offset %v", err)
+	var offset int64 = 0
+	if len(raw.Offset) > 0 {
+		offset, err = strconv.ParseInt(raw.Offset, 0, 64)
+		if err != nil {
+			return fmt.Errorf("Couldn't parse offset %v", err)
+		}
 	}
+
 	bytes, err := target.WriteAt(content, offset)
 	if bytes != len(content) {
 		return fmt.Errorf("Couldn't write complete data %v", err)


### PR DESCRIPTION
The documentation suggests that offset should be optional; in practice
offset isn't optional and the action will return an error out if unset:

    Action `` failed at stage Run, error: Couldn't parse offset strconv.ParseInt: parsing "": invalid syntax

So set the offset by default to 0 then only attempt to parse the parameter
from the YAML if it is explicitly set.

Fixes: b792b4722acb ("Add a raw action")

Signed-off-by: Christopher Obbard <chris.obbard@collabora.com>