### PR TITLE
actions: image-partition: Fix build failure

### DIFF
--- a/actions/image_partition_action.go
+++ b/actions/image_partition_action.go
@@ -287,8 +287,8 @@ func (i *ImagePartitionAction) triggerDeviceNodes(context *debos.DebosContext) e
 
 func (i ImagePartitionAction) PreMachine(context *debos.DebosContext, m *fakemachine.Machine,
 	args *[]string) error {
-	ImagePath := path.Join(context.Artifactdir, i.ImageName)
-	image, err := m.CreateImage(ImagePath, i.size)
+	imagePath := path.Join(context.Artifactdir, i.ImageName)
+	image, err := m.CreateImage(imagePath, i.size)
 	if err != nil {
 		return err
 	}
@@ -368,8 +368,8 @@ func (i ImagePartitionAction) formatPartition(p *Partition, context debos.DebosC
 
 func (i *ImagePartitionAction) PreNoMachine(context *debos.DebosContext) error {
 
-	ImagePath := path.Join(context.Artifactdir, i.ImageName)
-	img, err := os.OpenFile(ImagePath, os.O_WRONLY|os.O_CREATE, 0666)
+	imagePath := path.Join(context.Artifactdir, i.ImageName)
+	img, err := os.OpenFile(imagePath, os.O_WRONLY|os.O_CREATE, 0666)
 	if err != nil {
 		return fmt.Errorf("Couldn't open image file: %v", err)
 	}
@@ -381,7 +381,7 @@ func (i *ImagePartitionAction) PreNoMachine(context *debos.DebosContext) error {
 
 	img.Close()
 
-	i.loopDev, err = losetup.Attach(ImagePath, 0, false)
+	i.loopDev, err = losetup.Attach(imagePath, 0, false)
 	if err != nil {
 		return fmt.Errorf("Failed to setup loop device")
 	}

--- a/actions/image_partition_action.go
+++ b/actions/image_partition_action.go
@@ -367,7 +367,6 @@ func (i ImagePartitionAction) formatPartition(p *Partition, context debos.DebosC
 }
 
 func (i *ImagePartitionAction) PreNoMachine(context *debos.DebosContext) error {
-
 	imagePath := path.Join(context.Artifactdir, i.ImageName)
 	img, err := os.OpenFile(imagePath, os.O_WRONLY|os.O_CREATE, 0666)
 	if err != nil {

--- a/actions/image_partition_action.go
+++ b/actions/image_partition_action.go
@@ -368,7 +368,7 @@ func (i ImagePartitionAction) formatPartition(p *Partition, context debos.DebosC
 
 func (i *ImagePartitionAction) PreNoMachine(context *debos.DebosContext) error {
 
-	ImagePath = path.Join(context.Artifactdir, i.ImageName)
+	ImagePath := path.Join(context.Artifactdir, i.ImageName)
 	img, err := os.OpenFile(ImagePath, os.O_WRONLY|os.O_CREATE, 0666)
 	if err != nil {
 		return fmt.Errorf("Couldn't open image file: %v", err)


### PR DESCRIPTION
The linked commit doesn't correctly initialise new
variables, so go fails to build:

    ../../../go/src/github.com/go-debos/debos/actions/image_partition_action.go:371:2: undefined: ImagePath
    ../../../go/src/github.com/go-debos/debos/actions/image_partition_action.go:372:26: undefined: ImagePath
    ../../../go/src/github.com/go-debos/debos/actions/image_partition_action.go:384:34: undefined: ImagePath

So fix the initialisation of these variables, while
there improve the case of the variable names to be
more consistant with the rest of the project.

Fixes: a7afc01562bf ("actions/image-partition: Consistently use artifactdir")

Signed-off-by: Christopher Obbard <chris.obbard@collabora.com>

cc @punitagrawal