### PR TITLE
action/debootstrap: make suite property mandatory for debootstrap action

### DIFF
--- a/actions/debootstrap_action.go
+++ b/actions/debootstrap_action.go
@@ -110,6 +110,10 @@ func (d *DebootstrapAction) listOptionFiles(context *debos.DebosContext) []strin
 }
 
 func (d *DebootstrapAction) Verify(context *debos.DebosContext) error {
+	if len(d.Suite) == 0 {
+		return fmt.Errorf("suite property not specified")
+	}
+
 	files := d.listOptionFiles(context)
 
 	// Check if all needed files exists


### PR DESCRIPTION
Check if suite property is present for debootstarp action and contains
a string. If suite is not present, exit with an error.

Fixes: #238

Signed-off-by: Vignesh Raman <vignesh.raman@collabora.com>