### PR TITLE
actions/image-partition: check if the filesystem is mountable

### DIFF
--- a/actions/image_partition_action.go
+++ b/actions/image_partition_action.go
@@ -784,6 +784,10 @@ func (i *ImagePartitionAction) Verify(context *debos.DebosContext) error {
 		if m.part == nil {
 			return fmt.Errorf("Couldn't find partition for %s", m.Mountpoint)
 		}
+
+		if strings.ToLower(m.part.FS) == "none" {
+			return fmt.Errorf("Cannot mount %s: filesystem not present", m.Mountpoint)
+		}
 	}
 
 	// Calculate the size based on the unit (binary or decimal)


### PR DESCRIPTION
If the filesystem type is 'none', it results in the below error.
==== image-partition ====
Action `image-partition` failed at stage Run, error: root mount failed: no such device
Warning: Failed to get unmount /boot/efi: no such file or directory
Unmount failure can cause images being incomplete!
Powering off.

Report an error message if filesystem type is 'none' and exit.

Fixes: #234

Signed-off-by: Vignesh Raman <vignesh.raman@collabora.com>