### PR TITLE
debootstrap: Make sure /etc/apt/apt.conf.d exists

### DIFF
--- a/actions/debootstrap_action.go
+++ b/actions/debootstrap_action.go
@@ -208,6 +208,14 @@ func (d *DebootstrapAction) Run(context *debos.DebosContext) error {
 	cmdline = append(cmdline, d.Mirror)
 	cmdline = append(cmdline, "/usr/share/debootstrap/scripts/unstable")
 
+	/* Make sure /etc/apt/apt.conf.d exists inside the fakemachine otherwise
+	   debootstrap prints a warning about the path not existing. */
+	if fakemachine.InMachine() {
+		if err := os.MkdirAll(path.Join("/etc/apt/apt.conf.d"), os.ModePerm); err != nil {
+			return err
+		}
+	}
+
 	err := debos.Command{}.Run("Debootstrap", cmdline...)
 
 	if err != nil {


### PR DESCRIPTION
Currently running the debootstrap action inside a fakemachine results
in the following warning:

    Debootstrap | W: Unable to read /etc/apt/apt.conf.d/ - DirectoryExists (2: No such file or directory

Make sure the directory exists in the fakemachine host before running
the debootstrap command.

Fixes: #219

Signed-off-by: Christopher Obbard <chris.obbard@collabora.com>