### PR TITLE
actions/image-partition: truncate filesystem label to maximum supported length

### DIFF
--- a/actions/image_partition_action.go
+++ b/actions/image_partition_action.go
@@ -43,6 +43,7 @@ Yaml syntax for partitions:
      - name: partition name
 	   partlabel: partition label
 	   fs: filesystem
+	   fslabel: filesystem label
 	   start: offset
 	   end: offset
 	   features: list of filesystem features
@@ -71,6 +72,12 @@ Optional properties:
 
 - partlabel -- label for the partition in the GPT partition table. Defaults
 to the `name` property of the partition. May only be used for GPT partitions.
+
+- fslabel -- (optional) Sets the volume name (label) of the filesystem. Defaults
+to the `name` property of the partition. The filesystem label can be up to 11
+characters long for vfat, 16 characters long for ext2/3/4, 255 characters long
+for btrfs, 512 characters long for hfs/hfsplus and 12 characters long for xfs.
+Any longer labels will be automatically truncated.
 
 - parttype -- set the partition type in the partition table. The string should
 be in a hexadecimal format (2-characters) for msdos partition tables and GUID format
@@ -168,6 +175,7 @@ type Partition struct {
 	number    int
 	Name      string
 	PartLabel string
+	FSLabel   string
 	PartType  string
 	Start     string
 	End       string
@@ -305,10 +313,10 @@ func (i ImagePartitionAction) formatPartition(p *Partition, context debos.DebosC
 	cmdline := []string{}
 	switch p.FS {
 	case "vfat":
-		cmdline = append(cmdline, "mkfs.vfat", "-F32", "-n", p.Name)
+		cmdline = append(cmdline, "mkfs.vfat", "-F32", "-n", p.FSLabel)
 	case "btrfs":
 		// Force formatting to prevent failure in case if partition was formatted already
-		cmdline = append(cmdline, "mkfs.btrfs", "-L", p.Name, "-f")
+		cmdline = append(cmdline, "mkfs.btrfs", "-L", p.FSLabel, "-f")
 		if len(p.Features) > 0 {
 			cmdline = append(cmdline, "-O", strings.Join(p.Features, ","))
 		}
@@ -316,26 +324,26 @@ func (i ImagePartitionAction) formatPartition(p *Partition, context debos.DebosC
 			cmdline = append(cmdline, "-U", p.FSUUID)
 		}
 	case "f2fs":
-		cmdline = append(cmdline, "mkfs.f2fs", "-l", p.Name)
+		cmdline = append(cmdline, "mkfs.f2fs", "-l", p.FSLabel)
 		if len(p.Features) > 0 {
 			cmdline = append(cmdline, "-O", strings.Join(p.Features, ","))
 		}
 	case "hfs":
-		cmdline = append(cmdline, "mkfs.hfs", "-h", "-v", p.Name)
+		cmdline = append(cmdline, "mkfs.hfs", "-h", "-v", p.FSLabel)
 	case "hfsplus":
-		cmdline = append(cmdline, "mkfs.hfsplus", "-v", p.Name)
+		cmdline = append(cmdline, "mkfs.hfsplus", "-v", p.FSLabel)
 	case "hfsx":
-		cmdline = append(cmdline, "mkfs.hfsplus", "-s", "-v", p.Name)
+		cmdline = append(cmdline, "mkfs.hfsplus", "-s", "-v", p.FSLabel)
 		// hfsx is case-insensitive hfs+, should be treated as "normal" hfs+ from now on
 		p.FS = "hfsplus"
 	case "xfs":
-		cmdline = append(cmdline, "mkfs.xfs", "-L", p.Name)
+		cmdline = append(cmdline, "mkfs.xfs", "-L", p.FSLabel)
 		if len(p.FSUUID) > 0 {
 			cmdline = append(cmdline, "-m", "uuid="+p.FSUUID)
 		}
 	case "none":
 	default:
-		cmdline = append(cmdline, fmt.Sprintf("mkfs.%s", p.FS), "-L", p.Name)
+		cmdline = append(cmdline, fmt.Sprintf("mkfs.%s", p.FS), "-L", p.FSLabel)
 		if len(p.Features) > 0 {
 			cmdline = append(cmdline, "-O", strings.Join(p.Features, ","))
 		}
@@ -599,6 +607,7 @@ func (i *ImagePartitionAction) Verify(context *debos.DebosContext) error {
 
 	num := 1
 	for idx, _ := range i.Partitions {
+		var maxLength int = 0
 		p := &i.Partitions[idx]
 		p.number = num
 		num++
@@ -653,6 +662,31 @@ func (i *ImagePartitionAction) Verify(context *debos.DebosContext) error {
 			p.FS = "vfat"
 		case "":
 			return fmt.Errorf("Partition %s missing fs type", p.Name)
+		}
+
+		if p.FSLabel == "" {
+			p.FSLabel = p.Name
+		}
+
+		switch p.FS {
+			case "vfat":
+				maxLength = 11
+			case "ext2", "ext3", "ext4":
+				maxLength = 16
+			case "btrfs":
+				maxLength = 255
+			case "f2fs":
+				maxLength = 512
+			case "hfs", "hfsplus":
+				maxLength = 255
+			case "xfs":
+				maxLength = 12
+		}
+
+		if maxLength > 0 && len(p.FSLabel) > maxLength {
+			truncated := p.FSLabel[0:maxLength]
+			log.Printf("Warning: fs label for %s '%s' is too long; truncated to '%s'", p.Name, p.FSLabel, truncated)
+			p.FSLabel = truncated
 		}
 	}
 


### PR DESCRIPTION
Added optional fslabel property to partition to allow truncation of filesystem
label and allow user to modify filesystem label without modifying the name.
Filesystem label defaults to the name property of the partition.

The filesystem label can be up to 11 characters long for vfat, 16 characters
long for ext2/3/4, 255 characters long for btrfs, 512 characters long for
hfs/hfsplus and 12 characters long for xfs. Any longer labels will be
automatically truncated.

Fixes: #251

Suggested-by: Christopher Obbard <chris.obbard@collabora.com>
Signed-off-by: Vignesh Raman <vignesh.raman@collabora.com>