### PR TITLE
actions: run: Use argv[0] for label to reduce log spam

### DIFF
--- a/actions/run_action.go
+++ b/actions/run_action.go
@@ -103,6 +103,7 @@ func (run *RunAction) doRun(context debos.DebosContext) error {
 
 	if run.Script != "" {
 		script := strings.SplitN(run.Script, " ", 2)
+		label = script[0]
 		script[0] = debos.CleanPathAt(script[0], context.RecipeDir)
 		if run.Chroot {
 			scriptpath := path.Dir(script[0])
@@ -110,10 +111,10 @@ func (run *RunAction) doRun(context debos.DebosContext) error {
 			script[0] = strings.Replace(script[0], scriptpath, "/tmp/script", 1)
 		}
 		cmdline = []string{strings.Join(script, " ")}
-		label = path.Base(run.Script)
 	} else {
 		cmdline = []string{run.Command}
-		label = run.Command
+		label = strings.TrimSpace(cmdline[0])
+		label = strings.Split(label, " ")[0]
 	}
 
 	if run.Label != "" {


### PR DESCRIPTION
If it's not provided by the user, a label is created from the
command or script parameter which in some cases can be quite
long and can make the output more difficult to read.

Instead of using the whole command/script for the autogenerated
label, use only argv[0] of the first command to be ran to
preserve log space.

Test recipe:
```
architecture: amd64
actions:
  - action: run
    command: |
        echo "Testing testing 1234567890"
        echo "Testing testing 0987654321"
```

Log output without patch applied:
```
2021/08/10 12:30:21 ==== run ====
2021/08/10 12:30:21 echo "Testing testing 1234567890"
echo "Testing testing 0987654321"
 | Testing testing 1234567890
2021/08/10 12:30:21 echo "Testing testing 1234567890"
echo "Testing testing 0987654321"
 | Testing testing 0987654321
```

Log output with patch applied:
```
2021/08/10 12:30:45 ==== run ====
2021/08/10 12:30:45 echo | Testing testing 1234567890
2021/08/10 12:30:45 echo | Testing testing 0987654321
```

Signed-off-by: Christopher Obbard <chris.obbard@collabora.com>