### PR TITLE
actions: overlay: Log using action log functions

### DIFF
--- a/actions/overlay_action.go
+++ b/actions/overlay_action.go
@@ -26,6 +26,7 @@ package actions
 
 import (
 	"fmt"
+	"log"
 	"path"
 
 	"github.com/go-debos/debos"
@@ -63,5 +64,6 @@ func (overlay *OverlayAction) Run(context *debos.DebosContext) error {
 		return err
 	}
 
+	log.Printf("Overlaying %s on %s", sourcedir, destination)
 	return debos.CopyTree(sourcedir, destination)
 }

--- a/filesystem.go
+++ b/filesystem.go
@@ -58,7 +58,6 @@ func CopyFile(src, dst string, mode os.FileMode) error {
 }
 
 func CopyTree(sourcetree, desttree string) error {
-	fmt.Printf("Overlaying %s on %s\n", sourcetree, desttree)
 	walker := func(p string, info os.FileInfo, err error) error {
 
 		if err != nil {


### PR DESCRIPTION
Currently the overlay action prints directly to stdout, which
ends up not following the standard output format the other
actions follow. Let's clean this up by using the action's
existing logging functions rather than printing directly
to stdout.

Signed-off-by: Christopher Obbard <chris.obbard@collabora.com>