### PR TITLE
image_partition: add ability to skip "start" and specify relative offsets

### DIFF
--- a/actions/image_partition_action.go
+++ b/actions/image_partition_action.go
@@ -630,6 +630,17 @@ func CalculateOffset(start, end string) (string, error) {
 	return end, nil
 }
 
+func ValidPercentage(offset string) error {
+	val, typ, err := ParseOffset(offset)
+	if err != nil {
+		return err
+	}
+	if typ == "%" && val > 100 {
+		return fmt.Errorf("Size can not exceed 100%%")
+	}
+	return nil
+}
+
 func (i *ImagePartitionAction) Verify(context *debos.DebosContext) error {
 	if len(i.GptGap) > 0 {
 		log.Println("WARNING: special version of parted is needed for 'gpt_gap' option")
@@ -692,11 +703,22 @@ func (i *ImagePartitionAction) Verify(context *debos.DebosContext) error {
 		if p.Start == "" {
 			p.Start = prevEnd
 		}
+
+		err = ValidPercentage(p.Start)
+		if err != nil {
+			return err
+		}
+
 		if p.End == "" {
 			return fmt.Errorf("Partition %s missing end", p.Name)
 		}
 
 		p.End, err = CalculateOffset(p.Start, p.End)
+		if err != nil {
+			return err
+		}
+
+		err = ValidPercentage(p.End)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Currently start and end value must be specified explicitly

We can ignore start value unless required by using the end of
previous partition.

The size of partition can also be easier to see if using
end value as relative offset (e.g: +10Mib, +5%). However, 
the type of end value must be the same as start's

Example:
```
- action: image-partition
  imagename: "debian-rpi3.img"
  imagesize: 1GB
  partitiontype: msdos
  mountpoints:
    - mountpoint: /
      partition: root
    - mountpoint: /boot/firmware
      partition: firmware
      options: [ x-systemd.automount ]
  partitions:
    - name: firmware
      fs: vfat
      end: +5%
    - name: root
      fs: ext4
      start: 64MB
      end: +256MB
      flags: [ boot ]
```

firmware partition - start: 0% (as default), end: 5%
root partition - start: 64MB. end: 320MB