### PR TITLE
actions/image-partition: Allow binary unit measurements in the imagesize

### DIFF
--- a/actions/image_partition_action.go
+++ b/actions/image_partition_action.go
@@ -160,6 +160,7 @@ import (
 	"strings"
 	"syscall"
 	"time"
+	"regexp"
 
 	"github.com/go-debos/debos"
 )
@@ -678,7 +679,17 @@ func (i *ImagePartitionAction) Verify(context *debos.DebosContext) error {
 		}
 	}
 
-	size, err := units.FromHumanSize(i.ImageSize)
+	// Calculate the size based on the unit (binary or decimal)
+	// binary units are multiples of 1024 - KiB, MiB, GiB, TiB, PiB
+	// decimal units are multiples of 1000 - KB, MB, GB, TB, PB
+	var getSizeValueFunc func(size string) (int64, error)
+	if regexp.MustCompile(`^[0-9]+[kmgtp]ib+$`).MatchString(strings.ToLower(i.ImageSize)) {
+		getSizeValueFunc = units.RAMInBytes
+	} else {
+		getSizeValueFunc = units.FromHumanSize
+	}
+
+	size, err := getSizeValueFunc(i.ImageSize)
 	if err != nil {
 		return fmt.Errorf("Failed to parse image size: %s", i.ImageSize)
 	}


### PR DESCRIPTION
 Image partitions should be allowed to create with two different
 unit measurements binary and decimal.

 binary units(KiB, MiB, GiB, TiB, PiB) are calculated in multiples of 1024,
 and decimal units(KB, MB, GB, TB, PB) are caculated in multiples of 1000.

 e.g:
  imagesize: 1GiB = 1073741824
  imagesize: 1GB  = 1000000000

Signed-off-by: venkata pyla <venkata.pyla@toshiba-tsip.com>