### PR TITLE
actions/image-partition: allow extended and logical

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -128,9 +128,13 @@ jobs:
           - { name: "debian (amd64)", case: "debian", variables: "-t architecture:amd64" }
           - { name: "debian (arm64)", case: "debian", variables: "-t architecture:arm64" }
           - { name: "debian (armhf)", case: "debian", variables: "-t architecture:armhf" }
+          - { name: "partitioning", case: "partitioning" }
+          - { name: "msdos partitioning", case: "msdos" }
         exclude:
           - backend: nofakemachine
             test: { name: "partitioning", case: "partitioning" }
+          - backend: nofakemachine
+            test: { name: "msdos partitioning", case: "msdos" }
         include:
           - backend: kvm
             test: { name: "arch", case: "arch" }

--- a/actions/image_partition_action.go
+++ b/actions/image_partition_action.go
@@ -479,7 +479,7 @@ func (i ImagePartitionAction) Run(context *debos.DebosContext) error {
 		if i.PartitionType == "gpt" {
 			name = p.PartLabel
 		} else {
-			if cap(i.Partitions) <= 4 {
+			if len(i.Partitions) <= 4 {
 				name = "primary"
 			} else {
 				if idx < 3 {
@@ -670,7 +670,7 @@ func (i *ImagePartitionAction) Verify(context *debos.DebosContext) error {
 	for idx, _ := range i.Partitions {
 		p := &i.Partitions[idx]
 
-		if idx == 3 && cap(i.Partitions) > 4 {
+		if idx == 3 && len(i.Partitions) > 4 {
 			var name string
 			var part Partition
 
@@ -678,7 +678,7 @@ func (i *ImagePartitionAction) Verify(context *debos.DebosContext) error {
 			part.number    = idx+1
 			part.Name      = name
 			part.Start     = p.Start
-			tmp_n          := cap(i.Partitions)-1
+			tmp_n          := len(i.Partitions)-1
 			tmp            := &i.Partitions[tmp_n]
 			part.End       = tmp.End
 			part.FS        = "none"

--- a/tests/msdos/expected.json
+++ b/tests/msdos/expected.json
@@ -1,0 +1,57 @@
+{
+   "partitiontable": {
+      "label": "dos",
+      "id": "0xdeadbeef",
+      "device": "test.img",
+      "unit": "sectors",
+      "sectorsize": 512,
+      "partitions": [
+         {
+            "node": "test.img1",
+            "start": 1,
+            "size": 500000,
+            "type": "83"
+         },{
+            "node": "test.img2",
+            "start": 500001,
+            "size": 3406250,
+            "type": "83"
+         },{
+            "node": "test.img3",
+            "start": 3906251,
+            "size": 1953125,
+            "type": "83"
+         },{
+            "node": "test.img4",
+            "start": 5859376,
+            "size": 9765624,
+            "type": "f"
+         },{
+            "node": "test.img5",
+            "start": 5859377,
+            "size": 1953124,
+            "type": "83"
+         },{
+            "node": "test.img6",
+            "start": 7812502,
+            "size": 1953124,
+            "type": "83"
+         },{
+            "node": "test.img7",
+            "start": 9765627,
+            "size": 1953124,
+            "type": "83"
+         },{
+            "node": "test.img8",
+            "start": 11718752,
+            "size": 1953124,
+            "type": "83"
+         },{
+            "node": "test.img9",
+            "start": 13671877,
+            "size": 1953123,
+            "type": "83"
+         }
+      ]
+   }
+}

--- a/tests/msdos/test.yaml
+++ b/tests/msdos/test.yaml
@@ -1,0 +1,56 @@
+architecture: amd64
+
+actions:
+  - action: image-partition
+    description: Partition the image
+    imagename: test.img
+    imagesize: 8G
+    partitiontype: msdos
+    diskid: deadbeef
+    mountpoints:
+      - mounpoint: /
+        partition: system
+    partitions:
+      - name: boot
+        fs: ext2
+        start: 0%
+        end: 256M
+      - name: system
+        fs: ext4
+        start: 256m
+        end: 2G
+      - name: data0
+        fs: ext4
+        start: 2G
+        end: 3G
+      - name: data1
+        fs: ext4
+        start: 3G
+        end: 4G
+      - name: data2
+        fs: ext4
+        start: 4G
+        end: 5G
+      - name: data3
+        fs: ext4
+        start: 5G
+        end: 6G
+      - name: data4
+        fs: ext4
+        start: 6G
+        end: 7G
+      - name: data5
+        fs: ext4
+        start: 7G
+        end: 8G
+
+  - action: run
+    chroot: false
+    command: >
+      cd ${ARTIFACTDIR};
+      sfdisk -J test.img | tee ${RECIPEDIR}/actual.json
+
+  - action: run
+    description: Compare expected and actual
+    chroot: false
+    command: bash -c 'diff -u <(jq . ${RECIPEDIR}/expected.json) <(jq . ${RECIPEDIR}/actual.json)'


### PR DESCRIPTION
This commit allows us to create extended or logical
partitions on MBR partition table (msdos) in order to
address the following issues:

* Because part-type for parted is hardcoded with primary,
we cannot create more than 4 partitions using extended and
logical.

* Even if we manage to create extended and logical partitions,
the verificaton step fails because the Verify function assumes
that the partition number is always sequetially incremental.

This commit makes it possible that if the number of partitions
is more than 4, 3 of them are automatically created as primary,
1 of them is extended, and the remaining partitions are logical.

Signed-off-by: Daniel Sangorrin <daniel.sangorrin@toshiba.co.jp>
Signed-off-by: Daichi Fukui <daichi1.fukui@toshiba.co.jp>