### PR TITLE
Added verbose parameter in the README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ See [docker/README.md](https://github.com/go-debos/debos/blob/master/docker/READ
     sudo apt install golang git libglib2.0-dev libostree-dev qemu-system-x86 \
          qemu-user-static debootstrap systemd-container
     export GOPATH=/opt/src/gocode # or whatever suites your needs
-    go get -u github.com/go-debos/debos/cmd/debos
+    go get -u github.com/go-debos/debos/cmd/debos -v
     /opt/src/gocode/bin/debos --help
 
 ## Simple example


### PR DESCRIPTION
added verbose parameter ( -v) in the go get command to track progress during the install process on Debian