### PR TITLE
actions/overlay: Check source exists during recipe verification

### DIFF
--- a/actions/overlay_action.go
+++ b/actions/overlay_action.go
@@ -26,6 +26,7 @@ package actions
 
 import (
 	"fmt"
+	"os"
 	"path"
 
 	"github.com/go-debos/debos"
@@ -42,6 +43,13 @@ func (overlay *OverlayAction) Verify(context *debos.DebosContext) error {
 	if _, err := debos.RestrictedPath(context.Rootdir, overlay.Destination); err != nil {
 		return err
 	}
+
+	if len(overlay.Origin) == 0 {
+		if _, err := os.Stat(overlay.Source); err != nil {
+			return err
+		}
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
If an overlay coming from the recipe directory doesn't
exist, the recipe exits during execution. Let's check
early if the overlay exists on the host filesystem.

Signed-off-by: Christopher Obbard <chris.obbard@collabora.com>