### PR TITLE
Warn on execution with root user

### DIFF
--- a/cmd/debos/debos.go
+++ b/cmd/debos/debos.go
@@ -88,6 +88,10 @@ func main() {
 		"no_proxy",
 	}
 
+	if os.Getuid() == 0 {
+		log.Printf("Warning, you should not execute debos as root!")
+	}
+
 	var exitcode int = 0
 	// Allow to run all deferred calls prior to os.Exit()
 	defer func() {


### PR DESCRIPTION
Debos shouldn't be executed as root user, throw a warning if the user
attempts to do it anyway.

Signed-off-by: Sebastian Fricke <sebastian.fricke@collabora.com>