### PR TITLE
ci: Keep dependencies up-to-date using dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
Dependabot should automatically create pull requests when go
modules are updated. This should then run the CI scripts to
make sure fakemachine is built and tested on each supported
version of Go.

Signed-off-by: Christopher Obbard <chris.obbard@collabora.com>