### PR TITLE
For multiline commands, only use the first line and "..." as the label

### DIFF
--- a/actions/run_action.go
+++ b/actions/run_action.go
@@ -113,7 +113,13 @@ func (run *RunAction) doRun(context debos.DebosContext) error {
 		label = path.Base(run.Script)
 	} else {
 		cmdline = []string{run.Command}
-		label = run.Command
+		commands := strings.Split(run.Command, "\n")
+		label = commands[0]
+
+		// Make it clear a multi-line command is being run
+		if len(commands) > 1 {
+			label += "..."
+		}
 	}
 
 	if run.Label != "" {


### PR DESCRIPTION
When a multiline command is used with "run" action, it’s sometimes
difficult to figure out what’s going on, as it’s printed in its entirety
for the each line of its own output. For example:
```yaml
  - action: run
    chroot: false
    command: |
      echo test1
      echo test2
      echo test3
```
Prints this:

    2022/04/15 10:52:46 echo test1
    echo test2
    echo test3
     | test1
    2022/04/15 10:52:46 echo test1
    echo test2
    echo test3
     | test2
    2022/04/15 10:52:46 echo test1
    echo test2
    echo test3
     | test3

For clarity, it’s better to only use the first line:

    2022/04/15 11:03:10 echo test1... | test1
    2022/04/15 11:03:10 echo test1... | test2
    2022/04/15 11:03:10 echo test1... | test3