### PR TITLE
actions: image-partition: Remove extra warning about removing loop device

### DIFF
--- a/actions/image_partition_action.go
+++ b/actions/image_partition_action.go
@@ -571,7 +571,6 @@ func (i ImagePartitionAction) Cleanup(context *debos.DebosContext) error {
 			if err == nil {
 				break
 			}
-			log.Printf("Loop dev couldn't remove %s, waiting", err)
 			time.Sleep(time.Second)
 		}
 


### PR DESCRIPTION
When removing loop devices, we retry after a delay with
a timeout. Each time the loop device removal fails, a
warning message is printed to the log:

  "Loop dev couldn't remove could not remove, device in use, waiting"

This is pointless and could confuse the user. An error
while performing the loop device removal & retry is
logged seperately so let's remove the duplicate (and
confusing) log message.

Signed-off-by: Christopher Obbard <chris.obbard@collabora.com>