### PR TITLE
Only push to Dockerhub if run from upstream repository

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -194,7 +194,7 @@ jobs:
       - unit-tests
       - recipe-tests
       - uml-tests
-    if: github.event_name == 'push' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
+    if: github.event_name == 'push' && github.repository == 'go-debos/debos'
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
Seems like the conditional for checking main branch doesn't
work on forks; let's ensure that we only attempt to push to
Dockerhub if we are not in a fork.

Signed-off-by: Christopher Obbard <chris.obbard@collabora.com>