### PR TITLE
ci: Run workflow when tags are pushed

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,6 +7,8 @@ on:
   push:
     branches-ignore:
       - '*.tmp'
+    tags:
+      - '*'
   pull_request:
   workflow_dispatch:
 


### PR DESCRIPTION
Currently the workflow isn't ran when a tag is pushed; so the
docker images are not pushed to the registry. Fix it.

Signed-off-by: Christopher Obbard <chris.obbard@collabora.com>