### PR TITLE
README.md: add benchmarks for the different backends

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,18 @@ Fakemachine can use different virtualisation backends to spawn the virtualmachin
 for more information see the documentation under the [fakemachine repository](https://github.com/go-debos/fakemachine).
 
 By default the backend will automatically be selected based on what is supported
-on the host machine, but this can be overridden using the `--fakemachine-backend`
+on the host machine, but this can be overridden using the `--fakemachine-backend` / `-b`
 option. If no backends are supported, debos reverts to running the recipe on the
 host without creating a fakemachine.
+
+Performance of the backends is roughly as follows: `kvm` is faster than `uml` is faster than `qemu`.
+Using `--disable-fakemachine` is slightly faster than `kvm`, but requires root permissions.
+
+Numbers for running [pine-a64-plus/debian.yaml](https://github.com/go-debos/debos-recipes/blob/9a25b4be6c9136f4a27e542f39ab7e419fc852c9/pine-a64-plus/debian.yaml) on an Intel Pentium G4560T with SSD:
+
+| Backend | Wall Time | Prerequisites |
+| --- | --- | --- |
+| `--disable-fakemachine` | 8 min | root permissions |
+| `-b kvm` | 9 min | access to `/dev/kvm` |
+| `-b uml` | 18 min | package `user-mode-linux` installed  |
+| `-b qemu` | 166 min | none |


### PR DESCRIPTION
For me as a user it was unclear to me what kind of penalty there is for not allowing access to /dev/kvm, so I timed how long building pine-a64-plus/debian.yaml takes for the different backends.

I did not use the rpi recipes as they spend a lot of time downloading firmware blobs.

The tested debos version is 82c36d07b37c1818812ed63ec868c052f1b936a0 (current main at the time of writing) and the benchmarks have been run on an otherwise-idle box with the following specs:

* Debian Bullseye AMD64 (kernel 5.10.92)
* go version go1.15.15 linux/amd64
* 4 x Intel(R) Pentium(R) CPU G4560T @ 2.90GHz
* Fast M.2 SSD
* 24 GiB of RAM

For posterity, the very simple benchmark script is attached below:

  #!/bin/bash
  set -eux
  time sudo debos --disable-fakemachine debian.yaml
  time debos -b kvm debian.yaml
  time debos -b uml debian.yaml
  time debos -b qemu debian.yaml