### PR TITLE
godoc: add blank line in front of yaml examples

### DIFF
--- a/actions/apt_action.go
+++ b/actions/apt_action.go
@@ -4,6 +4,7 @@ Apt Action
 Install packages and their dependencies to the target rootfs with 'apt'.
 
 Yaml syntax:
+
  - action: apt
    recommends: bool
    unauthenticated: bool

--- a/actions/debootstrap_action.go
+++ b/actions/debootstrap_action.go
@@ -8,6 +8,7 @@ Most of the OS scripts used by `debootstrap` copy `resolv.conf` from the host,
 and this may lead to incorrect configuration when becoming part of the created rootfs.
 
 Yaml syntax:
+
  - action: debootstrap
    mirror: URL
    suite: "name"

--- a/actions/download_action.go
+++ b/actions/download_action.go
@@ -4,6 +4,7 @@ Download Action
 Download a single file from Internet and unpack it in place if needed.
 
 Yaml syntax:
+
  - action: download
    url: http://example.domain/path/filename.ext
    name: firmware

--- a/actions/filesystem_deploy_action.go
+++ b/actions/filesystem_deploy_action.go
@@ -10,6 +10,7 @@ After this action has ran, subsequent actions are executed on the mounted output
 image.
 
 Yaml syntax:
+
  - action: filesystem-deploy
    setup-fstab: bool
    setup-kernel-cmdline: bool

--- a/actions/image_partition_action.go
+++ b/actions/image_partition_action.go
@@ -8,6 +8,7 @@ mountpoints are sorted on their position in the filesystem hierarchy so the
 order in the recipe does not matter.
 
 Yaml syntax:
+
  - action: image-partition
    imagename: image_name
    imagesize: size

--- a/actions/ostree_commit_action.go
+++ b/actions/ostree_commit_action.go
@@ -4,6 +4,7 @@ OstreeCommit Action
 Create OSTree commit from rootfs.
 
 Yaml syntax:
+
  - action: ostree-commit
    repository: repository name
    branch: branch name

--- a/actions/ostree_deploy_action.go
+++ b/actions/ostree_deploy_action.go
@@ -8,6 +8,7 @@ during this step.
 Action 'image-partition' must be called prior to OSTree deploy.
 
 Yaml syntax:
+
  - action: ostree-deploy
    repository: repository name
    remote_repository: URL

--- a/actions/overlay_action.go
+++ b/actions/overlay_action.go
@@ -4,6 +4,7 @@ Overlay Action
 Recursive copy of directory or file to target filesystem.
 
 Yaml syntax:
+
  - action: overlay
    origin: name
    source: directory

--- a/actions/pack_action.go
+++ b/actions/pack_action.go
@@ -4,6 +4,7 @@ Pack Action
 Create tarball with filesystem.
 
 Yaml syntax:
+
  - action: pack
    file: filename.ext
    compression: gz

--- a/actions/raw_action.go
+++ b/actions/raw_action.go
@@ -5,6 +5,7 @@ Directly write a file to the output image at a given offset.
 This is typically useful for bootloaders.
 
 Yaml syntax:
+
  - action: raw
    origin: name
    source: filename

--- a/actions/recipe_action.go
+++ b/actions/recipe_action.go
@@ -12,6 +12,7 @@ Limitations of combined recipes are equivalent to limitations within a
 single recipe (e.g. there can only be one image partition action).
 
 Yaml syntax:
+
  - action: recipe
    recipe: path to recipe
    variables:

--- a/actions/run_action.go
+++ b/actions/run_action.go
@@ -6,6 +6,7 @@ in build process host environment: specifically inside the fakemachine created
 by Debos.
 
 Yaml syntax:
+
  - action: run
    chroot: bool
    postprocess: bool

--- a/actions/unpack_action.go
+++ b/actions/unpack_action.go
@@ -7,6 +7,7 @@ Useful for creating target rootfs from saved tarball with prepared file structur
 Only (compressed) tar archives are supported currently.
 
 Yaml syntax:
+
  - action: unpack
    origin: name
    file: file.ext


### PR DESCRIPTION
The yaml examples get somewhat mangled on godoc.org currently.

Example from https://pkg.go.dev/github.com/go-debos/debos/actions@main#hdr-Recipe_syntax :

  action: apt recommends: bool unauthenticated: bool update: bool packages:
  package1
  package2

Adding a blank line in front of the blocks makes the examples render as preformatted text.