### PR TITLE
docs: RawAction: list possible values for origin

### DIFF
--- a/actions/actions_doc.go
+++ b/actions/actions_doc.go
@@ -2,5 +2,16 @@
 
 /*
 Package 'actions' implements 'debos' modules used for OS creation.
+
+The origin property
+
+Several actions have the 'origin' property. Possible values for the
+'origin' property are:
+
+  1) 'recipe' ....... directory the recipe is in
+  2) 'filesystem' ... target filesystem root directory from previous filesystem-deploy action or
+                      a previous ostree action.
+  3) name property of a previous download action
+
 */
 package actions


### PR DESCRIPTION
Getting the raw action to work with an actual file was somewhat confusing for me.

Looking at the code, the origin is searched for in context.Origins, which is only set in three places:

 $ git grep Origins
 download_action.go:     context.Origins[d.Name] = originPath
 filesystem_deploy_action.go:    context.Origins["filesystem"] = context.ImageMntDir
 ostree_deploy_action.go:                context.Origins["filesystem"] = context.ImageMntDir

In addition, "recipe" is special-cased in DebosContext.Origin.

List all four options to hopefully make it less confusing for the next person.