### PR TITLE
Arch support - aka pacstrap, pacman and tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -125,6 +125,8 @@ jobs:
           - { name: "debian (arm64)", case: "debian", variables: "-t architecture:arm64" }
           - { name: "debian (armhf)", case: "debian", variables: "-t architecture:armhf" }
         include:
+          - backend: { name: "arch", backend: "--fakemachine-backend=qemu" }
+            test: { name: "arch", case: "arch" }
           - backend: { name: "qemu", backend: "--fakemachine-backend=qemu" }
             test: { name: "partitioning", case: "partitioning" }
           - backend: { name: "uml", backend: "--fakemachine-backend=uml" }

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Some of the actions provided by debos to customize and produce images are:
 * ostree-deploy: deploy an OSTree branch to the image
 * overlay: do a recursive copy of directories or files to the target filesystem
 * pack: create a tarball with the target filesystem
+* pacstrap: construct the target rootfs with pacstrap
 * raw: directly write a file to the output image at a given offset
 * recipe: includes the recipe actions at the given path
 * run: allows to run a command or script in the filesystem or in the host

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Some of the actions provided by debos to customize and produce images are:
 * ostree-deploy: deploy an OSTree branch to the image
 * overlay: do a recursive copy of directories or files to the target filesystem
 * pack: create a tarball with the target filesystem
+* pacman: install packages and their dependencies with pacman
 * pacstrap: construct the target rootfs with pacstrap
 * raw: directly write a file to the output image at a given offset
 * recipe: includes the recipe actions at the given path

--- a/actions/pacman_action.go
+++ b/actions/pacman_action.go
@@ -1,0 +1,39 @@
+/*
+Pacman Action
+
+Install packages and their dependencies to the target rootfs with 'pacman'.
+
+	# Yaml syntax:
+	- action: pacman
+	  packages:
+	    - package1
+	    - package2
+
+Mandatory properties:
+
+- packages -- list of packages to install
+*/
+package actions
+
+import (
+	"github.com/go-debos/debos"
+)
+
+type PacmanAction struct {
+	debos.BaseAction `yaml:",inline"`
+	Packages         []string
+}
+
+func (p *PacmanAction) Run(context *debos.DebosContext) error {
+	p.LogStart()
+
+	pacmanOptions := []string{"pacman", "-Syu", "--noconfirm"}
+	pacmanOptions = append(pacmanOptions, p.Packages...)
+
+	c := debos.NewChrootCommandForContext(*context)
+	if err := c.Run("pacman", pacmanOptions...); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/actions/pacstrap_action.go
+++ b/actions/pacstrap_action.go
@@ -1,0 +1,133 @@
+/*
+Pacstrap Action
+
+Construct the target rootfs with pacstrap tool.
+
+	# Yaml syntax:
+	- action: pacstrap
+	  config: <in-tree pacman.conf file>
+	  mirror: <in-tree mirrorlist file>
+
+Mandatory properties:
+
+  - config -- the pacman.conf file which will be used through the process
+  - mirror -- the mirrorlist file which will be used through the process
+*/
+package actions
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path"
+
+	"github.com/go-debos/debos"
+	"github.com/go-debos/fakemachine"
+)
+
+type PacstrapAction struct {
+	debos.BaseAction `yaml:",inline"`
+	Config           string `yaml:"config"`
+	Mirror           string `yaml:"mirror"`
+}
+
+func (d *PacstrapAction) listOptionFiles(context *debos.DebosContext) ([]string, error) {
+	files := []string{}
+
+	if d.Config == "" {
+		return nil, fmt.Errorf("No config file set")
+	}
+	d.Config = debos.CleanPathAt(d.Config, context.RecipeDir)
+	files = append(files, d.Config)
+
+	if d.Mirror == "" {
+		return nil, fmt.Errorf("No mirror file set")
+	}
+	d.Mirror = debos.CleanPathAt(d.Mirror, context.RecipeDir)
+	files = append(files, d.Mirror)
+
+	return files, nil
+}
+
+func (d *PacstrapAction) Verify(context *debos.DebosContext) error {
+	files, err := d.listOptionFiles(context)
+	if err != nil {
+		return err
+	}
+
+	// Check if all needed files exists
+	for _, f := range files {
+		if _, err := os.Stat(f); os.IsNotExist(err) {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (d *PacstrapAction) PreNoMachine(context *debos.DebosContext) error {
+	return fmt.Errorf("action requires fakemachine")
+}
+
+func (d *PacstrapAction) PreMachine(context *debos.DebosContext, m *fakemachine.Machine, args *[]string) error {
+	mounts, err := d.listOptionFiles(context)
+	if err != nil {
+		return err
+	}
+
+	// Mount configuration files outside of recipes directory
+	for _, mount := range mounts {
+		m.AddVolume(path.Dir(mount))
+	}
+
+	return nil
+}
+
+func (d *PacstrapAction) Run(context *debos.DebosContext) error {
+	d.LogStart()
+
+	files := map[string]string{
+		"/etc/pacman.conf":         d.Config,
+		"/etc/pacman.d/mirrorlist": d.Mirror,
+	}
+
+	// Copy the config/mirrorlist files
+	for dest, src := range files {
+		if err := os.MkdirAll(path.Dir(dest), 0755); err != nil {
+			return err
+		}
+
+		read, err := ioutil.ReadFile(src)
+		if err != nil {
+			return err
+		}
+
+		if err = ioutil.WriteFile(dest, read, 0644); err != nil {
+			return err
+		}
+	}
+
+	// Setup the local keychain, within the fakemachine instance, since we
+	// don't have access to the host one.
+	// Even if we did, blindly copying it might not be a good idea.
+	cmdline := []string{"pacman-key", "--init"}
+	if err := (debos.Command{}.Run("pacman-key", cmdline...)); err != nil {
+		return fmt.Errorf("Couldn't init pacman keyring: %v", err)
+	}
+
+	// When there's no explicit keyring suite we populate all available
+	cmdline = []string{"pacman-key", "--populate"}
+	if err := (debos.Command{}.Run("pacman-key", cmdline...)); err != nil {
+		return fmt.Errorf("Couldn't populate pacman keyring: %v", err)
+	}
+
+	// Run pacstrap
+	cmdline = []string{"pacstrap", context.Rootdir}
+	if err := (debos.Command{}.Run("pacstrap", cmdline...)); err != nil {
+		log := path.Join(context.Rootdir, "var/log/pacman.log")
+		_ = debos.Command{}.Run("pacstrap.log", "cat", log)
+		return err
+	}
+
+	return nil
+}

--- a/actions/recipe.go
+++ b/actions/recipe.go
@@ -55,6 +55,8 @@ Supported actions
 
 - pack -- https://godoc.org/github.com/go-debos/debos/actions#hdr-Pack_Action
 
+- pacstrap -- https://godoc.org/github.com/go-debos/debos/actions#hdr-Pacstrap_Action
+
 - raw -- https://godoc.org/github.com/go-debos/debos/actions#hdr-Raw_Action
 
 - recipe -- https://godoc.org/github.com/go-debos/debos/actions#hdr-Recipe_Action
@@ -100,6 +102,8 @@ func (y *YamlAction) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	switch aux.Action {
 	case "debootstrap":
 		y.Action = NewDebootstrapAction()
+	case "pacstrap":
+		y.Action = &PacstrapAction{}
 	case "pack":
 		y.Action = NewPackAction()
 	case "unpack":

--- a/actions/recipe.go
+++ b/actions/recipe.go
@@ -55,6 +55,8 @@ Supported actions
 
 - pack -- https://godoc.org/github.com/go-debos/debos/actions#hdr-Pack_Action
 
+- pacman -- https://godoc.org/github.com/go-debos/debos/actions#hdr-Pacman_Action
+
 - pacstrap -- https://godoc.org/github.com/go-debos/debos/actions#hdr-Pacstrap_Action
 
 - raw -- https://godoc.org/github.com/go-debos/debos/actions#hdr-Raw_Action
@@ -112,6 +114,8 @@ func (y *YamlAction) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		y.Action = &RunAction{}
 	case "apt":
 		y.Action = NewAptAction()
+	case "pacman":
+		y.Action = &PacmanAction{}
 	case "ostree-commit":
 		y.Action = &OstreeCommitAction{}
 	case "ostree-deploy":

--- a/doc/man/debos.1
+++ b/doc/man/debos.1
@@ -69,6 +69,8 @@ filesystem
 .IP \[bu] 2
 pack: create a tarball with the target filesystem
 .IP \[bu] 2
+pacstrap: construct the target rootfs with pacstrap
+.IP \[bu] 2
 raw: directly write a file to the output image at a given offset
 .IP \[bu] 2
 recipe: includes the recipe actions at the given path

--- a/doc/man/debos.1
+++ b/doc/man/debos.1
@@ -69,6 +69,8 @@ filesystem
 .IP \[bu] 2
 pack: create a tarball with the target filesystem
 .IP \[bu] 2
+pacman: install packages and their dependencies with pacman
+.IP \[bu] 2
 pacstrap: construct the target rootfs with pacstrap
 .IP \[bu] 2
 raw: directly write a file to the output image at a given offset

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -26,6 +26,22 @@ COPY . $GOPATH/src/github.com/go-debos/debos
 WORKDIR $GOPATH/src/github.com/go-debos/debos/cmd/debos
 RUN go install ./...
 
+# Pull the latest archlinux-keyring, since the one in Debian is outdated
+# https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1026080
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        pkgconf \
+        python3-all \
+        sq \
+        systemd && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN git clone https://gitlab.archlinux.org/archlinux/archlinux-keyring && \
+    cd archlinux-keyring && \
+    git checkout -B latest-release 20221213 && \
+    make build && \
+    make PREFIX=/usr KEYRING_TARGET_DIR=/usr/share/keyrings/ DESTDIR=/arch-keyring install
+
 ### second stage - runner ###
 FROM debian:bullseye-slim as runner
 
@@ -88,6 +104,21 @@ RUN apt-get update && \
         zip && \
     rm -rf /var/lib/apt/lists/*
 
+# Enable backports for the Arch dependencies
+RUN echo "deb http://ftp.debian.org/debian bullseye-backports main" >> /etc/apt/sources.list
+
+# NOTE: Explicitly install arch-install-scripts from backports. The normal one
+# lacks pactrap.
+# Install Arch dependencies
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        makepkg \
+        pacman-package-manager && \
+    apt-get install -y --no-install-recommends \
+        -t bullseye-backports \
+        arch-install-scripts && \
+    rm -rf /var/lib/apt/lists/*
+
 # debian's qemu-user-static package no longer registers binfmts
 # if running inside a virtualmachine; dockerhub builds are inside a vm
 RUN for arch in aarch64 alpha arm armeb cris hexagon hppa m68k microblaze mips mips64 mips64el mipsel mipsn32 mipsn32el ppc ppc64 ppc64le riscv32 riscv64 s390x sh4 sh4eb sparc sparc32plus sparc64 xtensa xtensaeb; do \
@@ -95,5 +126,9 @@ RUN for arch in aarch64 alpha arm armeb cris hexagon hppa m68k microblaze mips m
     done
 
 COPY --from=builder $GOPATH/bin/debos /usr/local/bin/debos
+
+# Pull the latest archlinux-keyring, since the one in Debian is outdated
+# https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1026080
+COPY --from=builder /arch-keyring/ /
 
 ENTRYPOINT ["/usr/local/bin/debos"]

--- a/tests/arch/mirrorlist
+++ b/tests/arch/mirrorlist
@@ -1,0 +1,3 @@
+Server = https://geo.mirror.pkgbuild.com/$repo/os/$arch
+Server = https://mirror.rackspace.com/archlinux/$repo/os/$arch
+Server = https://mirror.leaseweb.net/archlinux/$repo/os/$arch

--- a/tests/arch/pacman.conf
+++ b/tests/arch/pacman.conf
@@ -1,0 +1,101 @@
+#
+# /etc/pacman.conf
+#
+# See the pacman.conf(5) manpage for option and repository directives
+
+#
+# GENERAL OPTIONS
+#
+[options]
+# The following paths are commented out with their default values listed.
+# If you wish to use different paths, uncomment and update the paths.
+#RootDir     = /
+#DBPath      = /var/lib/pacman/
+#CacheDir    = /var/cache/pacman/pkg/
+#LogFile     = /var/log/pacman.log
+#GPGDir      = /etc/pacman.d/gnupg/
+#HookDir     = /etc/pacman.d/hooks/
+HoldPkg     = pacman glibc
+#XferCommand = /usr/bin/curl -L -C - -f -o %o %u
+#XferCommand = /usr/bin/wget --passive-ftp -c -O %o %u
+#CleanMethod = KeepInstalled
+Architecture = auto
+
+# Pacman won't upgrade packages listed in IgnorePkg and members of IgnoreGroup
+#IgnorePkg   =
+#IgnoreGroup =
+
+#NoUpgrade   =
+#NoExtract   =
+
+# Misc options
+#UseSyslog
+#Color
+#NoProgressBar
+CheckSpace
+#VerbosePkgLists
+#ParallelDownloads = 5
+
+# By default, pacman accepts packages signed by keys that its local keyring
+# trusts (see pacman-key and its man page), as well as unsigned packages.
+SigLevel    = Required DatabaseOptional
+LocalFileSigLevel = Optional
+#RemoteFileSigLevel = Required
+
+# NOTE: You must run `pacman-key --init` before first using pacman; the local
+# keyring can then be populated with the keys of all official Arch Linux
+# packagers with `pacman-key --populate archlinux`.
+
+#
+# REPOSITORIES
+#   - can be defined here or included from another file
+#   - pacman will search repositories in the order defined here
+#   - local/custom mirrors can be added here or in separate files
+#   - repositories listed first will take precedence when packages
+#     have identical names, regardless of version number
+#   - URLs will have $repo replaced by the name of the current repo
+#   - URLs will have $arch replaced by the name of the architecture
+#
+# Repository entries are of the format:
+#       [repo-name]
+#       Server = ServerName
+#       Include = IncludePath
+#
+# The header [repo-name] is crucial - it must be present and
+# uncommented to enable the repo.
+#
+
+# The testing repositories are disabled by default. To enable, uncomment the
+# repo name header and Include lines. You can add preferred servers immediately
+# after the header, and they will be used before the default mirrors.
+
+#[testing]
+#Include = /etc/pacman.d/mirrorlist
+
+[core]
+Include = /etc/pacman.d/mirrorlist
+
+[extra]
+Include = /etc/pacman.d/mirrorlist
+
+#[community-testing]
+#Include = /etc/pacman.d/mirrorlist
+
+[community]
+Include = /etc/pacman.d/mirrorlist
+
+# If you want to run 32 bit applications on your x86_64 system,
+# enable the multilib repositories as required here.
+
+#[multilib-testing]
+#Include = /etc/pacman.d/mirrorlist
+
+#[multilib]
+#Include = /etc/pacman.d/mirrorlist
+
+# An example of a custom package repository.  See the pacman manpage for
+# tips on creating your own repositories.
+#[custom]
+#SigLevel = Required DatabaseTrustedOnly
+#SigLevel = Optional TrustAll
+#Server = file:///home/custompkgs

--- a/tests/arch/test.yaml
+++ b/tests/arch/test.yaml
@@ -1,0 +1,13 @@
+---
+{{- $architecture := or .architecture "amd64"}}
+architecture: {{$architecture}}
+
+actions:
+  - action: pacstrap
+    config: pacman.conf
+    mirror: mirrorlist
+
+  - action: pacman
+    description: Install some base packages
+    packages:
+      - procps


### PR DESCRIPTION
This PR adds support for creating pacman based images (be that Arch or alike). Similar to the Debian variant we have two important actions - pacstrap and pacman.
 - pacstrap, requires pacman.conf and mirrorlist files
 - pacman is a simple list of packages, just like apt
 
 This PR supersedes https://github.com/go-debos/debos/pull/276 and https://github.com/go-debos/debos/pull/277, where the most significant changes are within the pacstrap action. In particular, we no longer write the config/mirrorlist files.

Considering that pacman is changing faster than debos, it makes sense to have the files as drop-ins instead of trying to hard-code them within debos itself.

Note: the final commit adds a simple CI file, which is not wired. Tips on how to achieve that would be appreciated.