### PR TITLE
image-partition: add unlock() in the error paths

### DIFF
--- a/actions/image_partition_action.go
+++ b/actions/image_partition_action.go
@@ -531,6 +531,7 @@ func (i ImagePartitionAction) Run(context *debos.DebosContext) error {
 		if err != nil {
 			return err
 		}
+		defer lock.unlock()
 
 		err = i.formatPartition(p, *context)
 		if err != nil {
@@ -566,6 +567,8 @@ func (i ImagePartitionAction) Run(context *debos.DebosContext) error {
 	if err != nil {
 		return err
 	}
+	defer lock.unlock()
+
 	for _, m := range i.Mountpoints {
 		dev := i.getPartitionDevice(m.part.number, *context)
 		mntpath := path.Join(context.ImageMntDir, m.Mountpoint)


### PR DESCRIPTION
Earlier commit added image locking around the partition handling. Yet we forgot to unlock in the error path - fix that.

Fixes: 1002e0a ("image-partition: Minimize the image lock scope")