### PR TITLE
tests: process json files throgh jq prior to comparing

### DIFF
--- a/tests/partitioning/test.yaml
+++ b/tests/partitioning/test.yaml
@@ -26,4 +26,4 @@ actions:
   - action: run
     description: Compare expected and actual
     chroot: false
-    command: diff -u ${RECIPEDIR}/expected.json ${RECIPEDIR}/actual.json
+    command: bash -c 'diff -u <(jq . ${RECIPEDIR}/expected.json) <(jq . ${RECIPEDIR}/actual.json)'


### PR DESCRIPTION
There are various whitespace changes that can occur in json files. Use the same pretty-format in both files to ensure the output is stable and consistent.

Note: we need to explicitly call "bash -c" here otherwise, we'll end up with pure POSIX shell (sh), where anonymous pipes are not a thing.

Signed-off-by: Emil Velikov <emil.velikov@collabora.com>