### PR TITLE
ci: remove deprecated set-output

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -244,12 +244,12 @@ jobs:
                 "${{ secrets.DOCKERHUB_PASSWORD }}" != "" ]]; \
           then
             echo "Dockerhub secrets exist"
-            echo "::set-output name=has-secrets::true"
+            echo "has-secrets=true" >> $GITHUB_OUTPUT
           else
             echo "Dockerhub secrets do not exist; not pushing to Dockerhub"
             echo "Please set the following secrets on GitHub (settings > secrets > actions > new):"
             echo "DOCKERHUB_IMAGE, DOCKERHUB_USERNAME, DOCKERHUB_PASSWORD"
-            echo "::set-output name=has-secrets::false"
+            echo "has-secrets=false" >> $GITHUB_OUTPUT
           fi
 
   publish-dockerhub:


### PR DESCRIPTION
The option is deprecated and we should be using $GITHUB_OUTPUT instead. See the official announcement for details:

https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
