### PR TITLE
image_partition_action.go: allow fraction sizes for binary units

### DIFF
--- a/actions/image_partition_action.go
+++ b/actions/image_partition_action.go
@@ -790,7 +790,7 @@ func (i *ImagePartitionAction) Verify(context *debos.DebosContext) error {
 	// binary units are multiples of 1024 - KiB, MiB, GiB, TiB, PiB
 	// decimal units are multiples of 1000 - KB, MB, GB, TB, PB
 	var getSizeValueFunc func(size string) (int64, error)
-	if regexp.MustCompile(`^[0-9]+[kmgtp]ib+$`).MatchString(strings.ToLower(i.ImageSize)) {
+	if regexp.MustCompile(`^[0-9.]+[kmgtp]ib+$`).MatchString(strings.ToLower(i.ImageSize)) {
 		getSizeValueFunc = units.RAMInBytes
 	} else {
 		getSizeValueFunc = units.FromHumanSize


### PR DESCRIPTION
The current filter for checking the size unit is not considered the fractions and it is wrongly filtered.
 e.g: 10.5GiB is filtered for or converted value as 10.5GB.

 Before fix:
  When size is 10.5GiB, the image is generated with 10500000000Bytes (wrong)

 After fix:
  When size is 10.5GiB, the image is generated with 11274289152Bytes (correct)

Suggested-by: Akihiro Suzuki <akihiro27.suzuki@toshiba.co.jp>