### PR TITLE
filesystem: Bubble up errors rather than panicing

### DIFF
--- a/filesystem.go
+++ b/filesystem.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"log"
 	"os"
 	"path"
 	"path/filepath"
@@ -70,18 +69,18 @@ func CopyTree(sourcetree, desttree string) error {
 		case 0:
 			err := CopyFile(p, target, info.Mode())
 			if err != nil {
-				log.Panicf("Failed to copy file %s: %v", p, err)
+				return fmt.Errorf("Failed to copy file %s: %w", p, err)
 			}
 		case os.ModeDir:
 			os.Mkdir(target, info.Mode())
 		case os.ModeSymlink:
 			link, err := os.Readlink(p)
 			if err != nil {
-				log.Panicf("Failed to read symlink %s: %v", suffix, err)
+				return fmt.Errorf("Failed to read symlink %s: %w", suffix, err)
 			}
 			os.Symlink(link, target)
 		default:
-			log.Panicf("Not handled /%s %v", suffix, info.Mode())
+			return fmt.Errorf("File %s with mode %v not handled", p, info.Mode())
 		}
 
 		return nil

--- a/tests/overlay-non-existent-destination/overlay-non-existent-destination.yaml
+++ b/tests/overlay-non-existent-destination/overlay-non-existent-destination.yaml
@@ -1,0 +1,17 @@
+architecture: amd64
+
+actions:
+  # This overlay action is expected to error out here because the destination
+  # doesn't exist in the filesystem.
+  - action: overlay
+    description: Overlay file into a non-existent destination
+    source: overlay-non-existent-destination.yaml
+    destination: /this/path/does/not/exist/overlay-non-existent-destination.yaml
+
+  - action: run
+    description: Check if path exists
+    command: "[ -e /this/path/does/not/exist/overlay-non-existent-destination.yaml ] || exit 1"
+
+  - action: run
+    postprocess: true
+    command: echo Test


### PR DESCRIPTION
If the overlay action fails to copy a file into the target filesystem
(e.g. destination path inside the filesystem doesn't exist), the current
behaviour is to panic, which causes a debos call inside the fakemachine
to panic, which isn't detected by the outer debos call.

This causes the exection of the inner debos call to stop (i.e. the
remaining recipe actions are no longer ran which is expected), but the
postexec commands still run and the overall exection is marked as
successful!

Rework the panics to instead bubble up errors so that any errors when
overlaying files causes the recipe to error out correctly rather than
this unexpected behaviour.