### PR TITLE
actions: apt: Don't show progress update percentages

### DIFF
--- a/actions/apt_action.go
+++ b/actions/apt_action.go
@@ -45,7 +45,14 @@ func NewAptAction() *AptAction {
 
 func (apt *AptAction) Run(context *debos.DebosContext) error {
 	apt.LogStart()
+
+	aptConfig := []string{}
+
+	/* Don't show progress update percentages */
+	aptConfig = append(aptConfig, "-o=quiet::NoUpdate=1")
+
 	aptOptions := []string{"apt-get", "-y"}
+	aptOptions = append(aptOptions, aptConfig...)
 
 	if !apt.Recommends {
 		aptOptions = append(aptOptions, "--no-install-recommends")
@@ -62,7 +69,11 @@ func (apt *AptAction) Run(context *debos.DebosContext) error {
 	c.AddEnv("DEBIAN_FRONTEND=noninteractive")
 
 	if apt.Update {
-		err := c.Run("apt", "apt-get", "update")
+		cmd := []string{"apt-get"}
+		cmd = append(cmd, aptConfig...)
+		cmd = append(cmd, "update")
+
+		err := c.Run("apt", cmd...)
 		if err != nil {
 			return err
 		}
@@ -72,7 +83,12 @@ func (apt *AptAction) Run(context *debos.DebosContext) error {
 	if err != nil {
 		return err
 	}
-	err = c.Run("apt", "apt-get", "clean")
+
+	cmd := []string{"apt-get"}
+	cmd = append(cmd, aptConfig...)
+	cmd = append(cmd, "clean")
+
+	err = c.Run("apt", cmd...)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Showing the update progress can cause non-interactive shells which do not support moving the cursor to become confused and not show the correct output. For instance, GitLab CI ignores any line which attempts to move the cursor, meaning some output for the apt action is just discarded.

Disable the apt progress from being shown and instead only showing the apt output log.