### PR TITLE
action: Remove *BaseAction.LogStart() function

### DIFF
--- a/action.go
+++ b/action.go
@@ -3,7 +3,6 @@ package debos
 import (
 	"bytes"
 	"github.com/go-debos/fakemachine"
-	"log"
 )
 
 type DebosState int
@@ -73,10 +72,6 @@ type Action interface {
 type BaseAction struct {
 	Action      string
 	Description string
-}
-
-func (b *BaseAction) LogStart() {
-	log.Printf("==== %s ====\n", b)
 }
 
 func (b *BaseAction) Verify(context *DebosContext) error { return nil }

--- a/actions/apt_action.go
+++ b/actions/apt_action.go
@@ -44,7 +44,6 @@ func NewAptAction() *AptAction {
 }
 
 func (apt *AptAction) Run(context *debos.DebosContext) error {
-	apt.LogStart()
 	aptOptions := []string{"apt-get", "-y"}
 
 	if !apt.Recommends {

--- a/actions/debootstrap_action.go
+++ b/actions/debootstrap_action.go
@@ -177,7 +177,6 @@ func (d *DebootstrapAction) isLikelyOldSuite() bool {
 }
 
 func (d *DebootstrapAction) Run(context *debos.DebosContext) error {
-	d.LogStart()
 	cmdline := []string{"debootstrap"}
 
 	if d.MergedUsr {

--- a/actions/download_action.go
+++ b/actions/download_action.go
@@ -125,7 +125,6 @@ func (d *DownloadAction) Verify(context *debos.DebosContext) error {
 
 func (d *DownloadAction) Run(context *debos.DebosContext) error {
 	var filename string
-	d.LogStart()
 
 	url, err := d.validateUrl()
 	if err != nil {

--- a/actions/filesystem_deploy_action.go
+++ b/actions/filesystem_deploy_action.go
@@ -117,7 +117,6 @@ func (fd *FilesystemDeployAction) setupKernelCmdline(context *debos.DebosContext
 }
 
 func (fd *FilesystemDeployAction) Run(context *debos.DebosContext) error {
-	fd.LogStart()
 	/* Copying files is actually silly hafd, one has to keep permissions, ACL's
 	 * extended attribute, misc, other. Leave it to cp...
 	 */

--- a/actions/image_partition_action.go
+++ b/actions/image_partition_action.go
@@ -444,8 +444,6 @@ func (i *ImagePartitionAction) PreNoMachine(context *debos.DebosContext) error {
 }
 
 func (i ImagePartitionAction) Run(context *debos.DebosContext) error {
-	i.LogStart()
-
 	/* On certain disk device events udev will call the BLKRRPART ioctl to
 	 * re-read the partition table. This will cause the partition devices
 	 * (e.g. vda3) to temporarily disappear while the rescanning happens.

--- a/actions/ostree_commit_action.go
+++ b/actions/ostree_commit_action.go
@@ -78,7 +78,6 @@ func emptyDir(dir string) {
 }
 
 func (ot *OstreeCommitAction) Run(context *debos.DebosContext) error {
-	ot.LogStart()
 	repoPath := path.Join(context.Artifactdir, ot.Repository)
 
 	emptyDir(path.Join(context.Rootdir, "dev"))

--- a/actions/ostree_deploy_action.go
+++ b/actions/ostree_deploy_action.go
@@ -104,8 +104,6 @@ func (ot *OstreeDeployAction) setupFSTab(deployment *ostree.Deployment, context 
 }
 
 func (ot *OstreeDeployAction) Run(context *debos.DebosContext) error {
-	ot.LogStart()
-
 	// This is to handle cases there we didn't partition an image
 	if len(context.ImageMntDir) != 0 {
 		/* First deploy the current rootdir to the image so it can seed e.g.

--- a/actions/overlay_action.go
+++ b/actions/overlay_action.go
@@ -47,7 +47,6 @@ func (overlay *OverlayAction) Verify(context *debos.DebosContext) error {
 }
 
 func (overlay *OverlayAction) Run(context *debos.DebosContext) error {
-	overlay.LogStart()
 	origin := context.RecipeDir
 
 	//Trying to get a filename from exports first

--- a/actions/pack_action.go
+++ b/actions/pack_action.go
@@ -68,7 +68,6 @@ func (pf *PackAction) Verify(context *debos.DebosContext) error {
 }
 
 func (pf *PackAction) Run(context *debos.DebosContext) error {
-	pf.LogStart()
 	usePigz := false
 	if pf.Compression == "gz" {
 		if _,err := exec.LookPath("pigz"); err == nil {

--- a/actions/pacman_action.go
+++ b/actions/pacman_action.go
@@ -25,8 +25,6 @@ type PacmanAction struct {
 }
 
 func (p *PacmanAction) Run(context *debos.DebosContext) error {
-	p.LogStart()
-
 	pacmanOptions := []string{"pacman", "-Syu", "--noconfirm"}
 	pacmanOptions = append(pacmanOptions, p.Packages...)
 

--- a/actions/pacstrap_action.go
+++ b/actions/pacstrap_action.go
@@ -84,8 +84,6 @@ func (d *PacstrapAction) PreMachine(context *debos.DebosContext, m *fakemachine.
 }
 
 func (d *PacstrapAction) Run(context *debos.DebosContext) error {
-	d.LogStart()
-
 	files := map[string]string{
 		"/etc/pacman.conf":         d.Config,
 		"/etc/pacman.d/mirrorlist": d.Mirror,

--- a/actions/raw_action.go
+++ b/actions/raw_action.go
@@ -84,7 +84,6 @@ func (raw *RawAction) Verify(context *debos.DebosContext) error {
 }
 
 func (raw *RawAction) Run(context *debos.DebosContext) error {
-	raw.LogStart()
 	origin, found := context.Origin(raw.Origin)
 	if !found {
 		return fmt.Errorf("Origin `%s` doesn't exist\n", raw.Origin)

--- a/actions/recipe_action.go
+++ b/actions/recipe_action.go
@@ -31,6 +31,7 @@ package actions
 import (
 	"errors"
 	"fmt"
+	"log"
 	"os"
 	"path/filepath"
 	"github.com/go-debos/debos"
@@ -114,9 +115,8 @@ func (recipe *RecipeAction) PreNoMachine(context *debos.DebosContext) error {
 }
 
 func (recipe *RecipeAction) Run(context *debos.DebosContext) error {
-	recipe.LogStart()
-
 	for _, a := range recipe.Actions.Actions {
+		log.Printf("==== %s ====\n", a.String())
 		if err := a.Run(&recipe.context); err != nil {
 			return err
 		}

--- a/actions/run_action.go
+++ b/actions/run_action.go
@@ -94,7 +94,6 @@ func (run *RunAction) PreMachine(context *debos.DebosContext, m *fakemachine.Mac
 }
 
 func (run *RunAction) doRun(context debos.DebosContext) error {
-	run.LogStart()
 	var cmdline []string
 	var label string
 	var cmd debos.Command

--- a/actions/unpack_action.go
+++ b/actions/unpack_action.go
@@ -67,7 +67,6 @@ func (pf *UnpackAction) Verify(context *debos.DebosContext) error {
 }
 
 func (pf *UnpackAction) Run(context *debos.DebosContext) error {
-	pf.LogStart()
 	var origin string
 
 	if len(pf.Origin) > 0 {

--- a/cmd/debos/debos.go
+++ b/cmd/debos/debos.go
@@ -28,6 +28,8 @@ func checkError(context *debos.DebosContext, err error, a debos.Action, stage st
 
 func do_run(r actions.Recipe, context *debos.DebosContext) int {
 	for _, a := range r.Actions {
+		log.Printf("==== %s ====\n", a.String())
+
 		err := a.Run(context)
 
 		// This does not stop the call of stacked Cleanup methods for other Actions


### PR DESCRIPTION
The LogStart() function was manually called at the start of each Run() function for each action to print the initial log line for each action (to print the action name/description). Move this logic to the main loop so that we don't need to reply on an action to remember to call this function.

(cc @evelikov)