### PR TITLE
ci: Add debian trixie to the test matrix

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,6 +24,7 @@ jobs:
           - debos-arch
           - debos-bookworm
           - debos-bullseye
+          - debos-trixie
     runs-on: ubuntu-latest
     defaults:
       run:


### PR DESCRIPTION
Requires https://github.com/go-debos/test-containers/pull/18