### PR TITLE
ci: Add linter stage to workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,6 +17,35 @@ on:
   workflow_dispatch:
 
 jobs:
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+    container:
+      image: ghcr.io/go-debos/test-containers/trixie:main
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+        filter: tree:0
+
+    - name: Add cwd as git safe directory
+      run: git config --global --add safe.directory $(pwd)
+
+    - name: Download dependencies
+      run: go mod tidy
+
+    - name: Pre-build otbuiltin package
+      run: go build github.com/sjoerdsimons/ostree-go/pkg/otbuiltin
+
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v8
+      with:
+        version: v2.3.1
+
   test:
     strategy:
       fail-fast: false
@@ -59,7 +88,9 @@ jobs:
   build:
     name: Build Docker container
     runs-on: ubuntu-latest
-    needs: test
+    needs:
+      - golangci
+      - test
     steps:
       - name: Repository checkout
         uses: actions/checkout@v4
@@ -277,6 +308,7 @@ jobs:
     name: allgreen
     if: always()
     needs:
+      - golangci
       - unit-tests
       - recipe-tests
       - example-recipes

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,6 @@
+version: "2"
+linters:
+  default: none
+formatters:
+  enable:
+    - gofmt

--- a/action.go
+++ b/action.go
@@ -40,18 +40,18 @@ type CommonContext struct {
 
 type DebosContext struct {
 	*CommonContext
-	RecipeDir       string
-	Architecture    string
-	SectorSize      int
+	RecipeDir    string
+	Architecture string
+	SectorSize   int
 }
 
 func (c *DebosContext) Origin(o string) (string, bool) {
-  if o == "recipe" {
-    return c.RecipeDir, true
-  } else {
-    path, found := c.Origins[o];
-    return path, found
-  }
+	if o == "recipe" {
+		return c.RecipeDir, true
+	} else {
+		path, found := c.Origins[o]
+		return path, found
+	}
 }
 
 type Action interface {

--- a/actions/actions_doc.go
+++ b/actions/actions_doc.go
@@ -3,16 +3,15 @@
 /*
 Package 'actions' implements 'debos' modules used for OS creation.
 
-The origin property
+# The origin property
 
 Several actions have the 'origin' property. Possible values for the
 'origin' property are:
 
-  1) 'recipe' ....... directory the recipe is in
-  2) 'filesystem' ... target filesystem root directory from previous filesystem-deploy action or
-                      a previous ostree action.
-  3) 'artifacts' .... directory the artifacts are stored in
-  4) name property of a previous download action
-
+ 1. 'recipe' ....... directory the recipe is in
+ 2. 'filesystem' ... target filesystem root directory from previous filesystem-deploy action or
+    a previous ostree action.
+ 3. 'artifacts' .... directory the artifacts are stored in
+ 4. name property of a previous download action
 */
 package actions

--- a/actions/apt_action.go
+++ b/actions/apt_action.go
@@ -3,14 +3,14 @@ Apt Action
 
 Install packages and their dependencies to the target rootfs with 'apt'.
 
- # Yaml syntax:
- - action: apt
-   recommends: bool
-   unauthenticated: bool
-   update: bool
-   packages:
-     - package1
-     - package2
+	# Yaml syntax:
+	- action: apt
+	  recommends: bool
+	  unauthenticated: bool
+	  update: bool
+	  packages:
+	    - package1
+	    - package2
 
 Mandatory properties:
 

--- a/actions/debootstrap_action.go
+++ b/actions/debootstrap_action.go
@@ -7,16 +7,16 @@ Please keep in mind -- file `/etc/resolv.conf` will be removed after execution.
 Most of the OS scripts used by `debootstrap` copy `resolv.conf` from the host,
 and this may lead to incorrect configuration when becoming part of the created rootfs.
 
- # Yaml syntax:
- - action: debootstrap
-   mirror: URL
-   suite: "name"
-   components: <list of components>
-   variant: "name"
-   keyring-package:
-   keyring-file:
-   certificate:
-   private-key:
+	# Yaml syntax:
+	- action: debootstrap
+	  mirror: URL
+	  suite: "name"
+	  components: <list of components>
+	  variant: "name"
+	  keyring-package:
+	  keyring-file:
+	  certificate:
+	  private-key:
 
 Mandatory properties:
 
@@ -26,16 +26,17 @@ Optional properties:
 
 - check-gpg -- verify GPG signatures on Release files, true by default
 
-- mirror -- URL with Debian-compatible repository
- If no mirror is specified debos will use http://deb.debian.org/debian as default.
+  - mirror -- URL with Debian-compatible repository
+    If no mirror is specified debos will use http://deb.debian.org/debian as default.
 
 - variant -- name of the bootstrap script variant to use
 
-- components -- list of components to use for packages selection.
- If no components are specified debos will use main as default.
+  - components -- list of components to use for packages selection.
+    If no components are specified debos will use main as default.
 
 Example:
- components: [ main, contrib ]
+
+	components: [ main, contrib ]
 
 - keyring-package -- keyring for package validation.
 
@@ -55,8 +56,8 @@ import (
 	"log"
 	"os"
 	"path"
-	"strings"
 	"runtime"
+	"strings"
 
 	"github.com/go-debos/debos"
 	"github.com/go-debos/fakemachine"

--- a/actions/download_action.go
+++ b/actions/download_action.go
@@ -3,13 +3,13 @@ Download Action
 
 Download a single file from Internet and unpack it in place if needed.
 
- # Yaml syntax:
- - action: download
-   url: http://example.domain/path/filename.ext
-   name: firmware
-   filename: output_name
-   unpack: bool
-   compression: gz
+	# Yaml syntax:
+	- action: download
+	  url: http://example.domain/path/filename.ext
+	  name: firmware
+	  filename: output_name
+	  unpack: bool
+	  compression: gz
 
 Mandatory properties:
 

--- a/actions/filesystem_deploy_action.go
+++ b/actions/filesystem_deploy_action.go
@@ -9,11 +9,11 @@ action requires 'image-partition' action to be executed before it.
 After this action has ran, subsequent actions are executed on the mounted output
 image.
 
- # Yaml syntax:
- - action: filesystem-deploy
-   setup-fstab: bool
-   setup-kernel-cmdline: bool
-   append-kernel-cmdline: arguments
+	# Yaml syntax:
+	- action: filesystem-deploy
+	  setup-fstab: bool
+	  setup-kernel-cmdline: bool
+	  append-kernel-cmdline: arguments
 
 Optional properties:
 

--- a/actions/image_partition_action.go
+++ b/actions/image_partition_action.go
@@ -7,17 +7,17 @@ build, and optionally (but by-default) mounted at boot in the final system. The
 mountpoints are sorted on their position in the filesystem hierarchy so the
 order in the recipe does not matter.
 
- # Yaml syntax:
- - action: image-partition
-   imagename: image_name
-   imagesize: size
-   partitiontype: gpt
-   diskid: string
-   gpt_gap: offset
-   partitions:
-     <list of partitions>
-   mountpoints:
-     <list of mount points>
+	# Yaml syntax:
+	- action: image-partition
+	  imagename: image_name
+	  imagesize: size
+	  partitiontype: gpt
+	  diskid: string
+	  gpt_gap: offset
+	  partitions:
+	    <list of partitions>
+	  mountpoints:
+	    <list of mount points>
 
 Mandatory properties:
 
@@ -45,21 +45,21 @@ should be in GUID format (e.g.: '00002222-4444-6666-AAAA-BBBBCCCCFFFF' where eac
 character is an hexadecimal digit). For 'msdos' partition table, 'diskid' should be
 a 32 bits hexadecimal number (e.g. '1234ABCD' without any dash separator).
 
-   # Yaml syntax for partitions:
-   partitions:
-     - name: partition name
-	   partlabel: partition label
-	   fs: filesystem
-	   fslabel: filesystem label
-	   start: offset
-	   end: offset
-	   features: list of filesystem features
-	   extendedoptions: list of filesystem extended options
-	   flags: list of flags
-	   fsck: bool
-	   fsuuid: string
-	   partuuid: string
-	   partattrs: list of partition attribute bits to set
+	   # Yaml syntax for partitions:
+	   partitions:
+	     - name: partition name
+		   partlabel: partition label
+		   fs: filesystem
+		   fslabel: filesystem label
+		   start: offset
+		   end: offset
+		   features: list of filesystem features
+		   extendedoptions: list of filesystem extended options
+		   flags: list of flags
+		   fsck: bool
+		   fsuuid: string
+		   partuuid: string
+		   partattrs: list of partition attribute bits to set
 
 Mandatory properties:
 
@@ -128,12 +128,12 @@ and data.
 - extendedoptions -- list of additional filesystem extended options which need
 to be enabled for the partition.
 
-   # Yaml syntax for mount points:
-   mountpoints:
-     - mountpoint: path
-	   partition: partition label
-	   options: list of options
-	   buildtime: bool
+	   # Yaml syntax for mount points:
+	   mountpoints:
+	     - mountpoint: path
+		   partition: partition label
+		   options: list of options
+		   buildtime: bool
 
 Mandatory properties:
 
@@ -154,27 +154,27 @@ to define a `mountpoint` path which is temporary and unique for the image,
 for example: `/mnt/temporary_mount`.
 Defaults to false.
 
- # Layout example for Raspberry PI 3:
- - action: image-partition
-   imagename: "debian-rpi3.img"
-   imagesize: 1GB
-   partitiontype: msdos
-   mountpoints:
-     - mountpoint: /
-       partition: root
-     - mountpoint: /boot/firmware
-       partition: firmware
-       options: [ x-systemd.automount ]
-   partitions:
-     - name: firmware
-       fs: vfat
-       start: 0%
-       end: 64MB
-     - name: root
-       fs: ext4
-       start: 64MB
-       end: 100%
-       flags: [ boot ]
+	# Layout example for Raspberry PI 3:
+	- action: image-partition
+	  imagename: "debian-rpi3.img"
+	  imagesize: 1GB
+	  partitiontype: msdos
+	  mountpoints:
+	    - mountpoint: /
+	      partition: root
+	    - mountpoint: /boot/firmware
+	      partition: firmware
+	      options: [ x-systemd.automount ]
+	  partitions:
+	    - name: firmware
+	      fs: vfat
+	      start: 0%
+	      end: 64MB
+	    - name: root
+	      fs: ext4
+	      start: 64MB
+	      end: 100%
+	      flags: [ boot ]
 */
 package actions
 
@@ -183,20 +183,20 @@ import (
 	"errors"
 	"fmt"
 	"github.com/docker/go-units"
+	"github.com/freddierice/go-losetup/v2"
 	"github.com/go-debos/fakemachine"
 	"github.com/google/uuid"
-	"github.com/freddierice/go-losetup/v2"
 	"log"
 	"os"
 	"os/exec"
 	"path"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strconv"
 	"strings"
 	"syscall"
 	"time"
-	"regexp"
 
 	"github.com/go-debos/debos"
 )
@@ -294,10 +294,10 @@ func (i *ImagePartitionAction) generateFSTab(context *debos.DebosContext) error 
 
 		fsType := m.part.FS
 		switch m.part.FS {
-			case "fat", "fat12", "fat16", "fat32", "msdos":
-				fsType = "vfat"
-			default:
-				break
+		case "fat", "fat12", "fat16", "fat32", "msdos":
+			fsType = "vfat"
+		default:
+			break
 		}
 
 		context.ImageFSTab.WriteString(fmt.Sprintf("UUID=%s\t%s\t%s\t%s\t0\t%d\n",
@@ -536,7 +536,7 @@ func (i ImagePartitionAction) Run(context *debos.DebosContext) error {
 		}
 	}
 
-	for idx, _ := range i.Partitions {
+	for idx := range i.Partitions {
 		p := &i.Partitions[idx]
 
 		if p.PartLabel == "" {
@@ -653,10 +653,10 @@ func (i ImagePartitionAction) Run(context *debos.DebosContext) error {
 		mntB := i.Mountpoints[b].Mountpoint
 
 		// root should always be mounted first
-		if (mntA == "/") {
+		if mntA == "/" {
 			return true
 		}
-		if (mntB == "/") {
+		if mntB == "/" {
 			return false
 		}
 
@@ -675,10 +675,10 @@ func (i ImagePartitionAction) Run(context *debos.DebosContext) error {
 		os.MkdirAll(mntpath, 0755)
 		fsType := m.part.FS
 		switch m.part.FS {
-			case "fat", "fat12", "fat16", "fat32", "msdos":
-				fsType = "vfat"
-			default:
-				break
+		case "fat", "fat12", "fat16", "fat32", "msdos":
+			fsType = "vfat"
+		default:
+			break
 		}
 		err = syscall.Mount(dev, mntpath, fsType, 0, "")
 		if err != nil {
@@ -767,7 +767,7 @@ func (i ImagePartitionAction) PostMachineCleanup(context *debos.DebosContext) er
 func (i *ImagePartitionAction) Verify(context *debos.DebosContext) error {
 
 	if i.PartitionType == "msdos" {
-		for idx, _ := range i.Partitions {
+		for idx := range i.Partitions {
 			p := &i.Partitions[idx]
 
 			if idx == 3 && len(i.Partitions) > 4 {
@@ -787,7 +787,7 @@ func (i *ImagePartitionAction) Verify(context *debos.DebosContext) error {
 				i.Partitions[idx] = part
 
 				num := 1
-				for idx, _ := range i.Partitions {
+				for idx := range i.Partitions {
 					p := &i.Partitions[idx]
 					p.number = num
 					num++
@@ -826,7 +826,7 @@ func (i *ImagePartitionAction) Verify(context *debos.DebosContext) error {
 	}
 
 	num := 1
-	for idx, _ := range i.Partitions {
+	for idx := range i.Partitions {
 		var maxLength int = 0
 		p := &i.Partitions[idx]
 		p.number = num
@@ -911,29 +911,29 @@ func (i *ImagePartitionAction) Verify(context *debos.DebosContext) error {
 		}
 
 		switch p.FS {
-			case "fat", "fat12", "fat16", "fat32", "msdos", "vfat":
-				maxLength = 11
-			case "ext2", "ext3", "ext4":
-				maxLength = 16
-			case "btrfs":
-				maxLength = 255
-			case "f2fs":
-				maxLength = 512
-			case "hfs", "hfsplus":
-				maxLength = 255
-			case "xfs":
-				maxLength = 12
-			case "none":
-			default:
-				log.Printf("Warning: setting a fs label for %s is unsupported", p.FS)
+		case "fat", "fat12", "fat16", "fat32", "msdos", "vfat":
+			maxLength = 11
+		case "ext2", "ext3", "ext4":
+			maxLength = 16
+		case "btrfs":
+			maxLength = 255
+		case "f2fs":
+			maxLength = 512
+		case "hfs", "hfsplus":
+			maxLength = 255
+		case "xfs":
+			maxLength = 12
+		case "none":
+		default:
+			log.Printf("Warning: setting a fs label for %s is unsupported", p.FS)
 		}
 
 		if maxLength > 0 && len(p.FSLabel) > maxLength {
-		        return fmt.Errorf("fs label for %s '%s' is too long", p.Name, p.FSLabel)
+			return fmt.Errorf("fs label for %s '%s' is too long", p.Name, p.FSLabel)
 		}
 	}
 
-	for idx, _ := range i.Mountpoints {
+	for idx := range i.Mountpoints {
 		m := &i.Mountpoints[idx]
 
 		// check for duplicate mountpoints
@@ -943,7 +943,7 @@ func (i *ImagePartitionAction) Verify(context *debos.DebosContext) error {
 			}
 		}
 
-		for pidx, _ := range i.Partitions {
+		for pidx := range i.Partitions {
 			p := &i.Partitions[pidx]
 			if m.Partition == p.Name {
 				m.part = p

--- a/actions/mmdebstrap_action.go
+++ b/actions/mmdebstrap_action.go
@@ -7,17 +7,17 @@ Please keep in mind -- file `/etc/resolv.conf` will be removed after execution.
 Most of the OS scripts used by `mmdebstrap` copy `resolv.conf` from the host,
 and this may lead to incorrect configuration when becoming part of the created rootfs.
 
- # Yaml syntax:
- - action: mmdebstrap
-   mirrors: <list of URLs>
-   suite: "name"
-   components: <list of components>
-   variant: "name"
-   keyring-packages:
-   keyring-files:
-   include:
-   dpkg-opts:
-   apt-opts:
+	# Yaml syntax:
+	- action: mmdebstrap
+	  mirrors: <list of URLs>
+	  suite: "name"
+	  components: <list of components>
+	  variant: "name"
+	  keyring-packages:
+	  keyring-files:
+	  include:
+	  dpkg-opts:
+	  apt-opts:
 
 Mandatory properties:
 
@@ -25,16 +25,17 @@ Mandatory properties:
 
 Optional properties:
 
-- mirrors -- list of URLs with Debian-compatible repository
- If no mirror is specified debos will use http://deb.debian.org/debian as default.
+  - mirrors -- list of URLs with Debian-compatible repository
+    If no mirror is specified debos will use http://deb.debian.org/debian as default.
 
 - variant -- name of the bootstrap script variant to use
 
-- components -- list of components to use for packages selection.
- If no components are specified debos will use main as default.
+  - components -- list of components to use for packages selection.
+    If no components are specified debos will use main as default.
 
 Example:
- components: [ main, contrib ]
+
+	components: [ main, contrib ]
 
 - keyring-packages -- list of keyrings for package validation.
 
@@ -47,7 +48,6 @@ Example:
 - dpkg-opts -- list of arbitrary options to dpkg.
 
 - apt-opts -- list of arbitrary options to apt.
-
 */
 package actions
 

--- a/actions/ostree_commit_action.go
+++ b/actions/ostree_commit_action.go
@@ -3,18 +3,18 @@ OstreeCommit Action
 
 Create OSTree commit from rootfs.
 
- # Yaml syntax:
- - action: ostree-commit
-   repository: repository name
-   branch: branch name
-   subject: commit message
-   collection-id: org.apertis.example
-   ref-binding:
-     - branch1
-     - branch2
-   metadata:
-     key: value
-     vendor.key: somevalue
+	# Yaml syntax:
+	- action: ostree-commit
+	  repository: repository name
+	  branch: branch name
+	  subject: commit message
+	  collection-id: org.apertis.example
+	  ref-binding:
+	    - branch1
+	    - branch2
+	  metadata:
+	    key: value
+	    vendor.key: somevalue
 
 Mandatory properties:
 
@@ -32,8 +32,8 @@ Optional properties:
 
 - collection-id -- Collection ID ref binding (requires libostree 2018.6).
 
-- ref-binding -- enforce that the commit was retrieved from one of the branch names in this array.
-  If 'collection-id' is set and 'ref-binding' is empty, will default to the branch name.
+  - ref-binding -- enforce that the commit was retrieved from one of the branch names in this array.
+    If 'collection-id' is set and 'ref-binding' is empty, will default to the branch name.
 
 - metadata -- key-value pairs of meta information to be added into commit.
 */

--- a/actions/ostree_deploy_action.go
+++ b/actions/ostree_deploy_action.go
@@ -7,18 +7,18 @@ during this step.
 
 Action 'image-partition' must be called prior to OSTree deploy.
 
- # Yaml syntax:
- - action: ostree-deploy
-   repository: repository name
-   remote_repository: URL
-   branch: branch name
-   os: os name
-   tls-client-cert-path: path to client certificate
-   tls-client-key-path: path to client certificate key
-   setup-fstab: bool
-   setup-kernel-cmdline: bool
-   appendkernelcmdline: arguments
-   collection-id: org.apertis.example
+	# Yaml syntax:
+	- action: ostree-deploy
+	  repository: repository name
+	  remote_repository: URL
+	  branch: branch name
+	  os: os name
+	  tls-client-cert-path: path to client certificate
+	  tls-client-key-path: path to client certificate key
+	  setup-fstab: bool
+	  setup-kernel-cmdline: bool
+	  appendkernelcmdline: arguments
+	  collection-id: org.apertis.example
 
 Mandatory properties:
 

--- a/actions/overlay_action.go
+++ b/actions/overlay_action.go
@@ -3,11 +3,11 @@ Overlay Action
 
 Recursive copy of directory or file to target filesystem.
 
- # Yaml syntax:
- - action: overlay
-   origin: name
-   source: directory
-   destination: directory
+	# Yaml syntax:
+	- action: overlay
+	  origin: name
+	  source: directory
+	  destination: directory
 
 Mandatory properties:
 

--- a/actions/pack_action.go
+++ b/actions/pack_action.go
@@ -3,10 +3,10 @@ Pack Action
 
 Create tarball with filesystem.
 
- # Yaml syntax:
- - action: pack
-   file: filename.ext
-   compression: gz
+	# Yaml syntax:
+	- action: pack
+	  file: filename.ext
+	  compression: gz
 
 Mandatory properties:
 
@@ -17,16 +17,15 @@ Optional properties:
 - compression -- compression type to use. Currently 'bzip2', 'gz', 'lzip', lzma', 'lzop',
 'xz' and 'zstd' compression types are supported. Use 'none' for uncompressed tarball.
 Use 'auto' to pick via file extension. The 'gz' compression type will be used by default.
-
 */
 package actions
 
 import (
 	"fmt"
 	"log"
+	"os/exec"
 	"path"
 	"strings"
-	"os/exec"
 
 	"github.com/go-debos/debos"
 )
@@ -75,7 +74,7 @@ func (pf *PackAction) Verify(context *debos.DebosContext) error {
 func (pf *PackAction) Run(context *debos.DebosContext) error {
 	usePigz := false
 	if pf.Compression == "gz" {
-		if _,err := exec.LookPath("pigz"); err == nil {
+		if _, err := exec.LookPath("pigz"); err == nil {
 			usePigz = true
 		}
 	}

--- a/actions/raw_action.go
+++ b/actions/raw_action.go
@@ -4,11 +4,11 @@ Raw Action
 Directly write a file to the output image at a given offset.
 This is typically useful for bootloaders.
 
- # Yaml syntax:
- - action: raw
-   origin: name
-   source: filename
-   offset: bytes
+	# Yaml syntax:
+	- action: raw
+	  origin: name
+	  source: filename
+	  offset: bytes
 
 Mandatory properties:
 

--- a/actions/recipe.go
+++ b/actions/recipe.go
@@ -1,7 +1,7 @@
 /*
 Package 'recipe' implements actions mapping to YAML recipe.
 
-Recipe syntax
+# Recipe syntax
 
 Recipe is a YAML file which is pre-processed though Golang
 text templating engine (https://golang.org/pkg/text/template)
@@ -14,22 +14,21 @@ Recipe is composed of 2 parts:
 
 Comments are allowed and should be prefixed with '#' symbol.
 
- # Declare variable 'Var'
- {{- $Var := "Value" -}}
+	# Declare variable 'Var'
+	{{- $Var := "Value" -}}
 
- # Header
- architecture: arm64
- sectorsize: 512
+	# Header
+	architecture: arm64
+	sectorsize: 512
 
- # Actions are executed in listed order
- actions:
-   - action: ActionName1
-     property1: true
+	# Actions are executed in listed order
+	actions:
+	  - action: ActionName1
+	    property1: true
 
-   - action: ActionName2
-     # Use value of variable 'Var' defined above
-     property2: {{$Var}}
-
+	  - action: ActionName2
+	    # Use value of variable 'Var' defined above
+	    property2: {{$Var}}
 
 The following custom template functions are available:
 
@@ -49,7 +48,7 @@ Optional properties for recipe:
 - sectorsize: Overrides the default 512 bytes sectorsize, mandatory for device using 4k block size such as UFS or NVMe storage. Setting the sectorsize to an
 other value than '512' is not supported by the 'uml' fakemachine backend.
 
-Supported actions
+# Supported actions
 
 - apt -- https://godoc.org/github.com/go-debos/debos/actions#hdr-Apt_Action
 
@@ -86,19 +85,19 @@ Supported actions
 package actions
 
 import (
+	"al.essio.dev/pkg/shellescape"
 	"bytes"
 	"fmt"
-	"al.essio.dev/pkg/shellescape"
 	"github.com/go-debos/debos"
-	"gopkg.in/yaml.v2"
 	"github.com/go-task/slim-sprig/v3"
-	"path"
-	"text/template"
+	"github.com/google/uuid"
+	"gopkg.in/yaml.v2"
 	"log"
+	"path"
+	"reflect"
 	"strconv"
 	"strings"
-	"reflect"
-	"github.com/google/uuid"
+	"text/template"
 )
 
 /* the YamlAction just embed the Action interface and implements the
@@ -205,7 +204,7 @@ func DumpActionStruct(iface interface{}) string {
 const tabs = 2
 
 func DumpActions(iface interface{}, depth int) {
-	tab := strings.Repeat(" ", depth * tabs)
+	tab := strings.Repeat(" ", depth*tabs)
 	entries := reflect.ValueOf(iface)
 
 	for i := 0; i < entries.NumField(); i++ {
@@ -214,7 +213,7 @@ func DumpActions(iface interface{}, depth int) {
 			actions := reflect.ValueOf(entries.Field(i).Interface())
 			for j := 0; j < actions.Len(); j++ {
 				yaml := reflect.ValueOf(actions.Index(j).Interface())
-				DumpActionFields(yaml.Field(0).Interface(), depth + 1)
+				DumpActionFields(yaml.Field(0).Interface(), depth+1)
 			}
 		} else {
 			log.Printf("%s  %s: %v\n", tab, entries.Type().Field(i).Name, entries.Field(i).Interface())
@@ -223,7 +222,7 @@ func DumpActions(iface interface{}, depth int) {
 }
 
 func DumpActionFields(iface interface{}, depth int) {
-	tab := strings.Repeat(" ", depth * tabs)
+	tab := strings.Repeat(" ", depth*tabs)
 	entries := reflect.ValueOf(iface).Elem()
 
 	for i := 0; i < entries.NumField(); i++ {
@@ -271,7 +270,7 @@ func (r *Recipe) Parse(file string, printRecipe bool, dump bool, templateVars ..
 	funcs := template.FuncMap{
 		"sector": sector,
 		"escape": escape,
-		"uuid5": uuid5,
+		"uuid5":  uuid5,
 	}
 	t.Funcs(funcs)
 

--- a/actions/recipe_action.go
+++ b/actions/recipe_action.go
@@ -11,11 +11,11 @@ passed in the "architecture" template variable.
 Limitations of combined recipes are equivalent to limitations within a
 single recipe (e.g. there can only be one image partition action).
 
- # Yaml syntax:
- - action: recipe
-   recipe: path to recipe
-   variables:
-     key: value
+	# Yaml syntax:
+	- action: recipe
+	  recipe: path to recipe
+	  variables:
+	    key: value
 
 Mandatory properties:
 
@@ -24,18 +24,17 @@ Mandatory properties:
 Optional properties:
 
 - variables -- overrides or adds new template variables.
-
 */
 package actions
 
 import (
 	"errors"
 	"fmt"
+	"github.com/go-debos/debos"
+	"github.com/go-debos/fakemachine"
 	"log"
 	"os"
 	"path/filepath"
-	"github.com/go-debos/debos"
-	"github.com/go-debos/fakemachine"
 )
 
 type RecipeAction struct {

--- a/actions/recipe_test.go
+++ b/actions/recipe_test.go
@@ -6,8 +6,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"io/ioutil"
 	"os"
-	"testing"
 	"strings"
+	"testing"
 )
 
 type testRecipe struct {
@@ -185,20 +185,20 @@ func runTest(t *testing.T, test testRecipe, templateVars ...map[string]string) a
 }
 
 type subRecipe struct {
-	name string
+	name   string
 	recipe string
 }
 
 type testSubRecipe struct {
-	recipe string
+	recipe    string
 	subrecipe subRecipe
-	err      string
-	parseErr string
+	err       string
+	parseErr  string
 }
 
 func TestSubRecipe(t *testing.T) {
 	// Embedded recipes
-	var recipeAmd64 = subRecipe {
+	var recipeAmd64 = subRecipe{
 		"amd64.yaml",
 		`
 architecture: amd64
@@ -208,7 +208,7 @@ actions:
     command: ok.sh
 `,
 	}
-	var recipeInheritedArch = subRecipe {
+	var recipeInheritedArch = subRecipe{
 		"inherited.yaml",
 		`
 {{- $architecture := or .architecture "armhf" }}
@@ -219,7 +219,7 @@ actions:
     command: ok.sh
 `,
 	}
-	var recipeArmhf = subRecipe {
+	var recipeArmhf = subRecipe{
 		"armhf.yaml",
 		`
 architecture: armhf
@@ -231,62 +231,62 @@ actions:
 	}
 
 	// test recipes
-	var tests = []testSubRecipe {
+	var tests = []testSubRecipe{
 		{
-		// Test recipe same architecture OK
-		`
+			// Test recipe same architecture OK
+			`
 architecture: amd64
 
 actions:
   - action: recipe
     recipe: amd64.yaml
 `,
-		recipeAmd64,
-		"", // Do not expect failure
-		"", // Do not expect parse failure
+			recipeAmd64,
+			"", // Do not expect failure
+			"", // Do not expect parse failure
 		},
 		{
-		// Test recipe with inherited architecture OK
-		`
+			// Test recipe with inherited architecture OK
+			`
 architecture: amd64
 
 actions:
   - action: recipe
     recipe: inherited.yaml
 `,
-		recipeInheritedArch,
-		"", // Do not expect failure
-		"", // Do not expect parse failure
+			recipeInheritedArch,
+			"", // Do not expect failure
+			"", // Do not expect parse failure
 		},
 		{
-		// Fail with unknown recipe
-		`
+			// Fail with unknown recipe
+			`
 architecture: amd64
 
 actions:
   - action: recipe
     recipe: unknown_recipe.yaml
 `,
-		recipeAmd64,
-		"stat /tmp/unknown_recipe.yaml: no such file or directory",
-		"", // Do not expect parse failure
+			recipeAmd64,
+			"stat /tmp/unknown_recipe.yaml: no such file or directory",
+			"", // Do not expect parse failure
 		},
 		{
-		// Fail with different architecture recipe
-		`
+			// Fail with different architecture recipe
+			`
 architecture: amd64
 
 actions:
   - action: recipe
     recipe: armhf.yaml
 `,
-		recipeArmhf,
-		"Expect architecture 'amd64' but got 'armhf'",
-		"", // Do not expect parse failure
+			recipeArmhf,
+			"Expect architecture 'amd64' but got 'armhf'",
+			"", // Do not expect parse failure
 		},
 		{
-		// Fail with type mismatch during parse
-		`
+			// Fail with type mismatch during parse
+			`
 architecture: armhf
 
 actions:
@@ -295,9 +295,9 @@ actions:
     variables:
       - foo
 `,
-		recipeArmhf,
-		"",
-		"yaml: unmarshal errors:\n  line 8: cannot unmarshal !!seq into map[string]string",
+			recipeArmhf,
+			"",
+			"yaml: unmarshal errors:\n  line 8: cannot unmarshal !!seq into map[string]string",
 		},
 	}
 
@@ -307,7 +307,7 @@ actions:
 }
 
 func runTestWithSubRecipes(t *testing.T, test testSubRecipe, templateVars ...map[string]string) actions.Recipe {
-	context := debos.DebosContext { &debos.CommonContext{}, "", "", 512 }
+	context := debos.DebosContext{&debos.CommonContext{}, "", "", 512}
 	dir, err := ioutil.TempDir("", "go-debos")
 	assert.Empty(t, err)
 	defer os.RemoveAll(dir)

--- a/actions/run_action.go
+++ b/actions/run_action.go
@@ -5,13 +5,13 @@ Allows to run any available command or script in the filesystem or
 in build process host environment: specifically inside the fakemachine created
 by Debos.
 
- # Yaml syntax:
- - action: run
-   chroot: bool
-   postprocess: bool
-   script: script name
-   command: command line
-   label: string
+	# Yaml syntax:
+	- action: run
+	  chroot: bool
+	  postprocess: bool
+	  script: script name
+	  command: command line
+	  label: string
 
 Properties 'command' and 'script' are mutually exclusive.
 
@@ -36,7 +36,6 @@ a label is derived from the command or script.
 - postprocess -- if set script or command is executed after all other commands and
 has access to the recipe directory ($RECIPEDIR) and the artifact directory ($ARTIFACTDIR).
 The working directory will be set to the artifact directory.
-
 
 Properties 'chroot' and 'postprocess' are mutually exclusive.
 */

--- a/actions/unpack_action.go
+++ b/actions/unpack_action.go
@@ -6,11 +6,11 @@ Useful for creating target rootfs from saved tarball with prepared file structur
 
 Only (compressed) tar archives are supported currently.
 
- # Yaml syntax:
- - action: unpack
-   origin: name
-   file: file.ext
-   compression: gz
+	# Yaml syntax:
+	- action: unpack
+	  origin: name
+	  file: file.ext
+	  compression: gz
 
 Mandatory properties:
 

--- a/archiver.go
+++ b/archiver.go
@@ -3,9 +3,9 @@ package debos
 import (
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
-	"os/exec"
 )
 
 type ArchiveType int

--- a/archiver_test.go
+++ b/archiver_test.go
@@ -83,7 +83,7 @@ func TestTar_compression(t *testing.T) {
 	arcType := archive.Type()
 	assert.Equal(t, debos.Tar, arcType)
 
-	for compression, _ := range compressions {
+	for compression := range compressions {
 		err = archive.AddOption("tarcompression", compression)
 		assert.Empty(t, err)
 		err := archive.Unpack("test")

--- a/cmd/debos/debos.go
+++ b/cmd/debos/debos.go
@@ -88,38 +88,37 @@ func warnLocalhost(variable string, value string) {
 		    Consider using an address that is valid on your network.`
 
 	if strings.Contains(value, "localhost") ||
-	   strings.Contains(value, "127.0.0.1") ||
-	   strings.Contains(value, "::1") {
+		strings.Contains(value, "127.0.0.1") ||
+		strings.Contains(value, "::1") {
 		log.Printf(message, variable)
 	}
 }
 
-
 func main() {
-	context := debos.DebosContext { &debos.CommonContext{}, "", "", 512 }
+	context := debos.DebosContext{&debos.CommonContext{}, "", "", 512}
 	var options struct {
-		Backend       string            `short:"b" long:"fakemachine-backend" description:"Fakemachine backend to use" default:"auto"`
-		ArtifactDir   string            `long:"artifactdir" description:"Directory for packed archives and ostree repositories (default: current directory)"`
-		InternalImage string            `long:"internal-image" hidden:"true"`
-		TemplateVars  map[string]string `short:"t" long:"template-var" description:"Template variables (use -t VARIABLE:VALUE syntax)"`
-		DebugShell    bool              `long:"debug-shell" description:"Fall into interactive shell on error"`
-		Shell         string            `short:"s" long:"shell" description:"Redefine interactive shell binary (default: bash)" optionsl:"" default:"/bin/bash"`
-		ScratchSize   string            `long:"scratchsize" description:"Size of disk-backed scratch space (parsed with human-readable suffix; assumed bytes if no suffix)"`
-		CPUs          int               `short:"c" long:"cpus" description:"Number of CPUs to use for build VM (default: 2)"`
-		Memory        string            `short:"m" long:"memory" description:"Amount of memory for build VM (parsed with human-readable suffix; assumed bytes if no suffix. default: 2Gb)"`
-		ShowBoot      bool              `long:"show-boot" description:"Show boot/console messages from the fake machine"`
-		EnvironVars   map[string]string `short:"e" long:"environ-var" description:"Environment variables (use -e VARIABLE:VALUE syntax)"`
-		Verbose       bool              `short:"v" long:"verbose" description:"Verbose output"`
-		PrintRecipe   bool              `long:"print-recipe" description:"Print final recipe"`
-		DryRun        bool              `long:"dry-run" description:"Compose final recipe to build but without any real work started"`
-		DisableFakeMachine bool         `long:"disable-fakemachine" description:"Do not use fakemachine."`
-		Version       bool              `long:"version" description:"Print debos version"`
+		Backend            string            `short:"b" long:"fakemachine-backend" description:"Fakemachine backend to use" default:"auto"`
+		ArtifactDir        string            `long:"artifactdir" description:"Directory for packed archives and ostree repositories (default: current directory)"`
+		InternalImage      string            `long:"internal-image" hidden:"true"`
+		TemplateVars       map[string]string `short:"t" long:"template-var" description:"Template variables (use -t VARIABLE:VALUE syntax)"`
+		DebugShell         bool              `long:"debug-shell" description:"Fall into interactive shell on error"`
+		Shell              string            `short:"s" long:"shell" description:"Redefine interactive shell binary (default: bash)" optionsl:"" default:"/bin/bash"`
+		ScratchSize        string            `long:"scratchsize" description:"Size of disk-backed scratch space (parsed with human-readable suffix; assumed bytes if no suffix)"`
+		CPUs               int               `short:"c" long:"cpus" description:"Number of CPUs to use for build VM (default: 2)"`
+		Memory             string            `short:"m" long:"memory" description:"Amount of memory for build VM (parsed with human-readable suffix; assumed bytes if no suffix. default: 2Gb)"`
+		ShowBoot           bool              `long:"show-boot" description:"Show boot/console messages from the fake machine"`
+		EnvironVars        map[string]string `short:"e" long:"environ-var" description:"Environment variables (use -e VARIABLE:VALUE syntax)"`
+		Verbose            bool              `short:"v" long:"verbose" description:"Verbose output"`
+		PrintRecipe        bool              `long:"print-recipe" description:"Print final recipe"`
+		DryRun             bool              `long:"dry-run" description:"Compose final recipe to build but without any real work started"`
+		DisableFakeMachine bool              `long:"disable-fakemachine" description:"Do not use fakemachine."`
+		Version            bool              `long:"version" description:"Print debos version"`
 	}
 
 	// These are the environment variables that will be detected on the
 	// host and propagated to fakemachine. These are listed lower case, but
 	// they are detected and configured in both lower case and upper case.
-	var environ_vars = [...]string {
+	var environ_vars = [...]string{
 		"http_proxy",
 		"https_proxy",
 		"ftp_proxy",


### PR DESCRIPTION
Ensure that submitted merge requests are run through a linter check to keep high code quality.

Initially run just a formatting check due to code quality issues. Once merged we can enable useful linters one-by-one after fixing each issue.

Closes: #378 