### PR TITLE
Check if artifactdir exists early

### DIFF
--- a/cmd/debos/debos.go
+++ b/cmd/debos/debos.go
@@ -201,6 +201,11 @@ func main() {
 		context.Artifactdir, _ = os.Getwd()
 	}
 	context.Artifactdir = debos.CleanPath(context.Artifactdir)
+	if dirInfo, err := os.Stat(context.Artifactdir); err != nil || !dirInfo.IsDir() {
+		log.Printf("artifactdir does not exist or is not a directory")
+		exitcode = 1
+		return
+	}
 
 	// Initialise origins map
 	context.Origins = make(map[string]string)


### PR DESCRIPTION
Currently debos fails if an action attempts to use artifactdir and it doesn't exist on the host:

  $ debos --artifactdir=out rpi64/debimage-rpi64.yaml
  Action `image-partition` failed at stage PreMachine, error: open /home/obbardc/projects/debos/debos-recipes/out/debian-rpi64.img: no such file or directory

Check that artifactdir exists early and return an error in case that it does not exist.

Closes: #426