### PR TITLE
docker: update to Debian 12 (Bookworm)

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,7 +3,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 ARG GOPATH=/usr/local/go
 
 ### first stage - builder ###
-FROM debian:bullseye-slim as builder
+FROM debian:bookworm-slim as builder
 
 ARG DEBIAN_FRONTEND
 ARG GOPATH
@@ -26,24 +26,8 @@ COPY . $GOPATH/src/github.com/go-debos/debos
 WORKDIR $GOPATH/src/github.com/go-debos/debos/cmd/debos
 RUN go install ./...
 
-# Pull the latest archlinux-keyring, since the one in Debian is outdated
-# https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1026080
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends \
-        pkgconf \
-        python3-all \
-        sq \
-        systemd && \
-    rm -rf /var/lib/apt/lists/*
-
-RUN git clone https://gitlab.archlinux.org/archlinux/archlinux-keyring && \
-    cd archlinux-keyring && \
-    git checkout -B latest-release 20221213 && \
-    make build && \
-    make PREFIX=/usr KEYRING_TARGET_DIR=/usr/share/keyrings/ DESTDIR=/arch-keyring install
-
 ### second stage - runner ###
-FROM debian:bullseye-slim as runner
+FROM debian:bookworm-slim as runner
 
 ARG DEBIAN_FRONTEND
 ARG GOPATH
@@ -96,26 +80,16 @@ RUN apt-get update && \
         rsync \
         systemd \
         systemd-container \
+        systemd-resolved \
         u-boot-tools \
         unzip \
         user-mode-linux \
         xfsprogs \
         xz-utils \
-        zip && \
-    rm -rf /var/lib/apt/lists/*
-
-# Enable backports for the Arch dependencies
-RUN echo "deb http://ftp.debian.org/debian bullseye-backports main" >> /etc/apt/sources.list
-
-# NOTE: Explicitly install arch-install-scripts from backports. The normal one
-# lacks pactrap.
-# Install Arch dependencies
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends \
+        zip \
         makepkg \
-        pacman-package-manager && \
-    apt-get install -y --no-install-recommends \
-        -t bullseye-backports \
+        pacman-package-manager \
+        archlinux-keyring \
         arch-install-scripts && \
     rm -rf /var/lib/apt/lists/*
 
@@ -126,9 +100,5 @@ RUN for arch in aarch64 alpha arm armeb cris hexagon hppa m68k microblaze mips m
     done
 
 COPY --from=builder $GOPATH/bin/debos /usr/local/bin/debos
-
-# Pull the latest archlinux-keyring, since the one in Debian is outdated
-# https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1026080
-COPY --from=builder /arch-keyring/ /
 
 ENTRYPOINT ["/usr/local/bin/debos"]


### PR DESCRIPTION
Bookworm is stable since June. So let's update the Dockerfile to use it so we can get rid of all the backports.
This required to add the systemd-resolved package as it was split into a separate package from systemd-networkd.

Motivation for the upgrade was have dpkg with zstd support so we can debootstrap Ubuntu again.