### PR TITLE
Be nicer to non-amd64 hosts

### DIFF
--- a/actions/debootstrap_action.go
+++ b/actions/debootstrap_action.go
@@ -56,6 +56,7 @@ import (
 	"os"
 	"path"
 	"strings"
+	"runtime"
 
 	"github.com/go-debos/debos"
 	"github.com/go-debos/fakemachine"
@@ -212,8 +213,8 @@ func (d *DebootstrapAction) Run(context *debos.DebosContext) error {
 		cmdline = append(cmdline, fmt.Sprintf("--components=%s", s))
 	}
 
-	/* FIXME drop the hardcoded amd64 assumption" */
-	foreign := context.Architecture != "amd64"
+	/* Only works for amd64, arm64 and riscv64 hosts, which should be enough */
+	foreign := context.Architecture != runtime.GOARCH
 
 	if foreign {
 		cmdline = append(cmdline, "--foreign")

--- a/commands.go
+++ b/commands.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/exec"
 	"path"
+	"runtime"
 )
 
 type ChrootEnterMethod int
@@ -292,19 +293,35 @@ func newQemuHelper(c Command) qemuHelper {
 
 	switch c.Architecture {
 	case "armhf", "armel", "arm":
-		q.qemusrc = "/usr/bin/qemu-arm-static"
+		if runtime.GOARCH != "arm64" && runtime.GOARCH != "arm" {
+			q.qemusrc = "/usr/bin/qemu-arm-static"
+		}
 	case "arm64":
-		q.qemusrc = "/usr/bin/qemu-aarch64-static"
+		if runtime.GOARCH != "arm64" {
+			q.qemusrc = "/usr/bin/qemu-aarch64-static"
+		}
 	case "mips":
 		q.qemusrc = "/usr/bin/qemu-mips-static"
 	case "mipsel":
-		q.qemusrc = "/usr/bin/qemu-mipsel-static"
+		if runtime.GOARCH != "mips64le" && runtime.GOARCH != "mipsle" {
+			q.qemusrc = "/usr/bin/qemu-mipsel-static"
+		}
 	case "mips64el":
-		q.qemusrc = "/usr/bin/qemu-mips64el-static"
+		if runtime.GOARCH != "mips64le" {
+			q.qemusrc = "/usr/bin/qemu-mips64el-static"
+		}
 	case "riscv64":
-		q.qemusrc = "/usr/bin/qemu-riscv64-static"
-	case "amd64", "i386":
-		/* Dummy, no qemu */
+		if runtime.GOARCH != "riscv64" {
+			q.qemusrc = "/usr/bin/qemu-riscv64-static"
+		}
+	case "i386":
+		if runtime.GOARCH != "amd64" && runtime.GOARCH != "386" {
+			q.qemusrc = "/usr/bin/qemu-i386-static"
+		}
+	case "amd64":
+		if runtime.GOARCH != "amd64" {
+			q.qemusrc = "/usr/bin/qemu-x86_64-static"
+		}
 	default:
 		log.Panicf("Don't know qemu for Architecture %s", c.Architecture)
 	}


### PR DESCRIPTION
With fakemachine now being compatible with arm64 hosts, it is possible to build and run debos on this architecture. However, it will still assume it runs on amd64, hence executing actions in the chroot through qemu and calling debootstrap with the `--foreign` flag set, even when building for the same architecture.

This PR makes use of runtime architecture detection to avoid those unnecessary tricks.