### PR TITLE
ci: use generic test container

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,10 +21,10 @@ jobs:
       fail-fast: false
       matrix:
         variant:
-          - debos-arch
-          - debos-bookworm
-          - debos-bullseye
-          - debos-trixie
+          - arch
+          - bookworm
+          - bullseye
+          - trixie
     runs-on: ubuntu-latest
     defaults:
       run:


### PR DESCRIPTION
In go-debos/test-containers#30 we simplified the test containers by only creating one container for both fakemachine/debos instead of creating separate containers for each project. Use the new container.

Draft because:
- Depends on https://github.com/go-debos/test-containers/pull/30
- Container tag needs to change to main