### PR TITLE
docker: Install archlinux-keyring from source

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -26,6 +26,24 @@ COPY . $GOPATH/src/github.com/go-debos/debos
 WORKDIR $GOPATH/src/github.com/go-debos/debos/cmd/debos
 RUN go install ./...
 
+# Install the latest archlinux-keyring, since the one in Debian is bound
+# to get outdated sooner or later.
+# WARNING: returning to the debian package will break the pacstrap action
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        pkgconf \
+        python3-all \
+        sq \
+        systemd \
+        make && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN git clone https://gitlab.archlinux.org/archlinux/archlinux-keyring && \
+    cd archlinux-keyring && \
+    git checkout master && \
+    make build && \
+    make PREFIX=/usr KEYRING_TARGET_DIR=/usr/share/keyrings/ DESTDIR=/arch-keyring install
+
 ### second stage - runner ###
 FROM debian:bookworm-slim as runner
 
@@ -89,7 +107,6 @@ RUN apt-get update && \
         zip \
         makepkg \
         pacman-package-manager \
-        archlinux-keyring \
         arch-install-scripts && \
     rm -rf /var/lib/apt/lists/*
 
@@ -100,5 +117,10 @@ RUN for arch in aarch64 alpha arm armeb cris hexagon hppa m68k microblaze mips m
     done
 
 COPY --from=builder $GOPATH/bin/debos /usr/local/bin/debos
+
+# Install the latest archlinux-keyring, since the one in Debian is bound
+# to get outdated sooner or later.
+# WARNING: returning to the debian package will break the pacstrap action
+COPY --from=builder /arch-keyring/usr/share/keyrings /usr/share/keyrings
 
 ENTRYPOINT ["/usr/local/bin/debos"]


### PR DESCRIPTION
The arch linux tests require a newer version of archlinux-keyring than what is in Debian stable; so revert back to pulling the latest version.

This partially reverts 36cf33366bbe0dd602185a87a241ff070517f868.