### PR TITLE
Docker: Add Debian ports keyring

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -77,6 +77,7 @@ RUN apt-get update && \
         busybox \
         bzip2 \
         ca-certificates \
+        debian-ports-archive-keyring \
         debootstrap \
         dosfstools \
         e2fsprogs \


### PR DESCRIPTION
This adds the Debian ports keyring, which allows debootstrapping Debian port architectures (see https://www.ports.debian.org/).

Fixes #463.