### PR TITLE
docker: Add troubleshooting for permission errors on /dev/kvm

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -20,6 +20,8 @@ cd <PATH_TO_RECIPE_DIR>
 docker run --rm --interactive --tty --device /dev/kvm --user $(id -u) --workdir /recipes --mount "type=bind,source=$(pwd),destination=/recipes" --security-opt label=disable godebos/debos <RECIPE.yaml>
 ```
 
+If debos fails to run the KVM fakemachine backend and the `/dev/kvm` device exists on your host, you may need to add the owning group of the device as a supplementary group of the container. This will work if `ls -l /dev/kvm` indicates that the owning group has read-write access to the device. Adding the supplementary group may be unsafe depending on the owning group of `/dev/kvm`, but it could be required depending on your login provider. To add the group, add `--group-add "$(stat -c '%g' /dev/kvm)"` to your `docker run` command before `godebos/debos`. See [Docker run reference -- Additional Groups](https://docs.docker.com/engine/reference/run/#additional-groups) for more information.
+
 ## Container build
 To build the debos container image from current git branch:
 ```


### PR DESCRIPTION
I got a `permission denied` error when trying to use the KVM fakemachine backend on a host. The Docker documentation indicates that "the docker container process runs with the supplementary groups looked up for the specified user," but I suspect this means the groups _inside_ the container are looked up. I added the owning group of `/dev/kvm` (which happened to be `kvm`) to the container and all is well.