### PR TITLE
Add option to quiet fakemachine

### DIFF
--- a/cmd/debos/debos.go
+++ b/cmd/debos/debos.go
@@ -316,6 +316,9 @@ func main() {
 			}
 		}
 
+		// Silence extra output from fakemachine unless the --verbose flag was passed.
+		m.SetQuiet(!options.Verbose)
+
 		exitcode, err = m.RunInMachineWithArgs(args)
 		if err != nil {
 			fmt.Println(err)


### PR DESCRIPTION
Hi! Thanks for the work on this useful project.

We have successfully been using debos for some time, but it always prints the whole debos invocation, which causes secrets passed into debos as variables (e.g. account passwords, private keys) to be written to our CI logs. I looked into this and found that it was because fakemachine logs the command it runs by default, though it has an option to suppress this. I saw no way of setting this option through debos, though, hence this pull request.

This pull request adds the flag "--quiet-fakemachine" because it was the least intrusive change, but on a second thought, it looks a bit odd. I think it might make more sense to use the quiet option in fakemachine by default, and let the existing debos flag "--verbose" disable it instead. What do you think? Any approach that lets us pass a variable without having it written to log is fine with us.