### PR TITLE
commands: Set nspawn console mode to pipe

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -229,6 +229,7 @@ func (cmd Command) Run(label string, cmdline ...string) error {
 		options = append(options, "--timezone=off")
 		options = append(options, "--register=no")
 		options = append(options, "--keep-unit")
+		options = append(options, "--console=pipe")
 		for _, e := range cmd.extraEnv {
 			options = append(options, "--setenv", e)
 


### PR DESCRIPTION
Currently the default nspawn console mode for nspawn is interactive which means that /dev/console is created inside the nspawn container and the command can assume it is running in an interactive session.

With console mode set to pipe, nspawn doesn't create /dev/console inside the container and scripts assume they are running in an interactive environment

This has the benefit of forcing some commands (e.g. apt) to not show things like progress bars which only work in interactive terminals.

Fixes: #411
Fixes: #416