### PR TITLE
docker: Use prebuild archlinux keyring

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -13,6 +13,7 @@ ENV GOPATH=${GOPATH}
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
         ca-certificates \
+        curl \
         gcc \
         git \
         golang-go \
@@ -29,20 +30,8 @@ RUN go install ./...
 # Install the latest archlinux-keyring, since the one in Debian is bound
 # to get outdated sooner or later.
 # WARNING: returning to the debian package will break the pacstrap action
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends \
-        pkgconf \
-        python3-all \
-        sq \
-        systemd \
-        make && \
-    rm -rf /var/lib/apt/lists/*
-
-RUN git clone https://gitlab.archlinux.org/archlinux/archlinux-keyring && \
-    cd archlinux-keyring && \
-    git checkout master && \
-    make build && \
-    make PREFIX=/usr KEYRING_TARGET_DIR=/usr/share/keyrings/ DESTDIR=/arch-keyring install
+COPY docker/get-archlinux-keyring.sh /
+RUN /get-archlinux-keyring.sh /arch-keyring
 
 ### second stage - runner ###
 FROM debian:bookworm-slim as runner
@@ -122,6 +111,6 @@ COPY --from=builder $GOPATH/bin/debos /usr/local/bin/debos
 # Install the latest archlinux-keyring, since the one in Debian is bound
 # to get outdated sooner or later.
 # WARNING: returning to the debian package will break the pacstrap action
-COPY --from=builder /arch-keyring/usr/share/keyrings /usr/share/keyrings
+COPY --from=builder /arch-keyring /usr/share/keyrings
 
 ENTRYPOINT ["/usr/local/bin/debos"]

--- a/docker/get-archlinux-keyring.sh
+++ b/docker/get-archlinux-keyring.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+LINK=https://gitlab.archlinux.org/archlinux/archlinux-keyring/-/releases/permalink/latest
+TARGET="${1:-.}"
+
+RELEASE=$(curl  -s -I -o /dev/null -w '%header{location}\n' \
+          ${LINK} \
+          | sed 's/.*\///')
+
+echo Arch keyring release ${RELEASE}
+echo Installing to ${TARGET}
+mkdir -p ${TARGET}
+curl -s -L ${LINK}/downloads/archlinux-keyring-${RELEASE}.tar.gz \
+        | tar xvz --strip-components=1 -C ${TARGET}


### PR DESCRIPTION
Currently rebuilding the arch keyring on Debian bookworm is broken as the build depends  on newer sq options. There is no reason to re-build the keyring though, debian also uses a pre-build version to package it for example.

Switch to use a script to download the latest release from arch gitlab