### PR TITLE
docker: Add zstd to the docker image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -95,6 +95,7 @@ RUN apt-get update && \
         xfsprogs \
         xz-utils \
         zip \
+        zstd \
         makepkg \
         pacman-package-manager \
         arch-install-scripts && \


### PR DESCRIPTION
zstd compresses as well as gzip or xz (depending on compression ratio) but has superiour performance; Add it to the docker image so it can be used in recipes more easily.