### PR TITLE
actions: Document 'artifacts' value for the origin property

### DIFF
--- a/actions/actions_doc.go
+++ b/actions/actions_doc.go
@@ -11,7 +11,8 @@ Several actions have the 'origin' property. Possible values for the
   1) 'recipe' ....... directory the recipe is in
   2) 'filesystem' ... target filesystem root directory from previous filesystem-deploy action or
                       a previous ostree action.
-  3) name property of a previous download action
+  3) 'artifacts' .... directory the artifacts are stored in
+  4) name property of a previous download action
 
 */
 package actions


### PR DESCRIPTION
The 'artifacts' value for the origin property was missing from the documentation. Add it.