### PR TITLE
Don't ignore YAML parsing errors

### DIFF
--- a/actions/recipe.go
+++ b/actions/recipe.go
@@ -147,7 +147,10 @@ func (y *YamlAction) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		return fmt.Errorf("Unknown action: %v", aux.Action)
 	}
 
-	unmarshal(y.Action)
+	err = unmarshal(y.Action)
+	if err != nil {
+		return err
+	}
 
 	return nil
 }


### PR DESCRIPTION
When we're unpacking individual actions, pass YAML parsing errors up to the caller instead of silently ignoring them.

Also add a test that checks that debos more obviously errors out when you do what I tried to do.