### PR TITLE
download: Actually validate empty pathnames

### DIFF
--- a/actions/download_action.go
+++ b/actions/download_action.go
@@ -76,7 +76,7 @@ func (d *DownloadAction) validateFilename(context *debos.DebosContext, url *url.
 	} else {
 		filename = path.Base(d.Filename)
 	}
-	if len(filename) == 0 {
+	if len(filename) == 0 || filename == "." || filename == "/" {
 		return "", fmt.Errorf("Incorrect filename is provided for '%s'", d.Url)
 	}
 	filename = path.Join(context.Scratchdir, filename)


### PR DESCRIPTION
From the path module doc:
    If the path is empty, Base returns ".". If the path consists
    entirely of slashes, Base returns "/".

Actually validate that we provide a filename when one is required, rather than failing with an error that /scratch exists but is not a file.