### PR TITLE
actions: Fix regression introduced with FAT{12|16|32} support.

### DIFF
--- a/actions/image_partition_action.go
+++ b/actions/image_partition_action.go
@@ -602,7 +602,14 @@ func (i ImagePartitionAction) Run(context *debos.DebosContext) error {
 		dev := i.getPartitionDevice(m.part.number, *context)
 		mntpath := path.Join(context.ImageMntDir, m.Mountpoint)
 		os.MkdirAll(mntpath, 0755)
-		err = syscall.Mount(dev, mntpath, m.part.FS, 0, "")
+		fsType := m.part.FS
+		switch m.part.FS {
+			case "fat", "fat12", "fat16", "fat32", "msdos":
+				fsType = "vfat"
+			default:
+				break
+		}
+		err = syscall.Mount(dev, mntpath, fsType, 0, "")
 		if err != nil {
 			return fmt.Errorf("%s mount failed: %v", m.part.Name, err)
 		}


### PR DESCRIPTION
The regression was introduced with the following commit :

    commit 94fedb2c0c8a97ceb7c9b153aefa81c8d94ce57b
    Author: Christopher Obbard <chris.obbard@collabora.com>
    Date:   Tue Mar 19 17:43:42 2024 +0000
    actions: image-partition: enable creation of FAT{12|16|32} partitions

This one added more options when it comes to creating FAT partitions. So when partition fs is defined as "fat", "fat12", "fat16", "fat32", "msdos" or "vfat", then mkfs.vfat is used to create the partition, and different options were used depending on the FAT type.

The main issue is that  mounting a FAT partition should  use "vfat"
 as fs type when using syscall.Mount().

So, in order to fix this issue, "vfat" is simply used to mount "fat", "fat12", "fat16", "fat32" or "msdos" partitions.