### PR TITLE
actions: fix fstab generated in case of FAT{12|16|32}.

### DIFF
--- a/actions/image_partition_action.go
+++ b/actions/image_partition_action.go
@@ -270,8 +270,17 @@ func (i *ImagePartitionAction) generateFSTab(context *debos.DebosContext) error 
 				fs_passno = 2
 			}
 		}
+
+		fsType := m.part.FS
+		switch m.part.FS {
+			case "fat", "fat12", "fat16", "fat32", "msdos":
+				fsType = "vfat"
+			default:
+				break
+		}
+
 		context.ImageFSTab.WriteString(fmt.Sprintf("UUID=%s\t%s\t%s\t%s\t0\t%d\n",
-			m.part.FSUUID, m.Mountpoint, m.part.FS,
+			m.part.FSUUID, m.Mountpoint, fsType,
 			strings.Join(options, ","), fs_passno))
 	}
 


### PR DESCRIPTION
Recent changes introduced a tuned formatting of the partitions created with FAT{12|16|32}. The issue is that fstab is generated using the fs property which won't match the system expectations.

If the fs property is "fat", "fat12", "fat16", "fat32" or "msdos", then fstab must use "vfat".