### PR TITLE
docker: Add arm64-based Dockerfile

### DIFF
--- a/docker/Dockerfile.arm64
+++ b/docker/Dockerfile.arm64
@@ -1,0 +1,98 @@
+# Global ARGs shared by all stages
+ARG DEBIAN_FRONTEND=noninteractive
+ARG GOPATH=/usr/local/go
+
+### first stage - builder ###
+FROM arm64v8/debian:bookworm-slim as builder
+
+ARG DEBIAN_FRONTEND
+ARG GOPATH
+ENV GOPATH=${GOPATH}
+
+# install debos build and unit-test dependencies
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        ca-certificates \
+        gcc \
+        git \
+        golang-go \
+        libc6-dev \
+        libostree-dev \
+        unzip && \
+    rm -rf /var/lib/apt/lists/*
+
+# Build debos
+COPY . $GOPATH/src/github.com/go-debos/debos
+WORKDIR $GOPATH/src/github.com/go-debos/debos/cmd/debos
+RUN go install ./...
+
+### second stage - runner ###
+FROM arm64v8/debian:bookworm-slim as runner
+
+ARG DEBIAN_FRONTEND
+ARG GOPATH
+
+# Set HOME to a writable directory in case something wants to cache things
+ENV HOME=/tmp
+
+LABEL org.label-schema.name "debos"
+LABEL org.label-schema.description "Debian OS builder"
+LABEL org.label-schema.vcs-url = "https://github.com/go-debos/debos"
+LABEL org.label-schema.docker.cmd 'docker run \
+  --rm \
+  --interactive \
+  --tty \
+  --device /dev/kvm \
+  --user $(id -u) \
+  --workdir /recipes \
+  --mount "type=bind,source=$(pwd),destination=/recipes" \
+  --security-opt label=disable'
+
+# debos runtime dependencies
+# ca-certificates is required to validate HTTPS certificates when getting debootstrap release file
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        apt-transport-https \
+        binfmt-support \
+        bmap-tools \
+        btrfs-progs \
+        busybox \
+        bzip2 \
+        ca-certificates \
+        debootstrap \
+        dosfstools \
+        e2fsprogs \
+        equivs \
+        fdisk \
+        f2fs-tools \
+        git \
+        gzip \
+        pigz \
+        libostree-1-1 \
+        libslirp-helper \
+        linux-image-arm64 \
+        openssh-client \
+        parted \
+        pkg-config \
+        qemu-system-arm \
+        qemu-user-static \
+        qemu-utils \
+        rsync \
+        systemd \
+        systemd-container \
+        u-boot-tools \
+        unzip \
+        xfsprogs \
+        xz-utils \
+        zip && \
+    rm -rf /var/lib/apt/lists/*
+
+# debian's qemu-user-static package no longer registers binfmts
+# if running inside a virtualmachine; dockerhub builds are inside a vm
+RUN for arch in aarch64 alpha arm armeb cris hexagon hppa m68k microblaze mips mips64 mips64el mipsel mipsn32 mipsn32el ppc ppc64 ppc64le riscv32 riscv64 s390x sh4 sh4eb sparc sparc32plus sparc64 xtensa xtensaeb; do \
+      update-binfmts --import qemu-$arch; \
+    done
+
+COPY --from=builder $GOPATH/bin/debos /usr/local/bin/debos
+
+ENTRYPOINT ["/usr/local/bin/debos"]


### PR DESCRIPTION
I needed an arm64-based Docker image to run debos but it seems like you don't provide one.

This PR contains the Dockerfile I use to build images on arm64. Arch Linux specific things (notably the archlinux-keyring) aren't installed and handled at all, but seeing that https://github.com/go-debos/debos/issues/483 is open this might be put into a separate conatiner for building Arch Linux images anyway?

Feel free to merge if you're okay with the Dockerfile and want to support arm64-based Docker images upstream. Of course I'm open to improve this as well.

Thanks!