### PR TITLE
docker: Add arm64 builds to Dockerfile and CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -133,7 +133,7 @@ jobs:
 
       - name: Run unit tests
         run: |
-          docker-compose -f docker/unit-tests.test.yml \
+          docker compose -f docker/unit-tests.test.yml \
             up --exit-code-from=sut
 
   recipe-tests:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,6 +2,7 @@ name: Build and Test
 
 env:
   GITHUB_TAG: ghcr.io/${{ github.repository }}
+  DOCKER_TARGET_PLATFORMS: linux/amd64,linux/arm64
 
 on:
   push:
@@ -51,6 +52,9 @@ jobs:
       - name: Repository checkout
         uses: actions/checkout@v4
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Setup Docker buildx
         uses: docker/setup-buildx-action@v3
 
@@ -67,6 +71,26 @@ jobs:
           push: false
           pull: true
           file: docker/Dockerfile
+          platforms: ${{ env.DOCKER_TARGET_PLATFORMS }}
+          tags: debos
+          cache-from: type=local,src=/tmp/.build-cache
+          cache-to: type=local,dest=/tmp/.build-cache,mode=max
+
+      # WORKAROUND:
+      # Docker buildx cannot export multi-platform images with type=docker,
+      # but only with type=oci. The latter cannot be imported without an
+      # intermediate registry. Thus export only the amd64 image for usage
+      # in the test stage.
+      #
+      # see https://docs.docker.com/reference/cli/docker/buildx/build/#docker
+      - name: Export amd64 Docker image for later usage
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: false
+          pull: true
+          file: docker/Dockerfile
+          platforms: linux/amd64
           tags: debos
           cache-from: type=local,src=/tmp/.build-cache
           cache-to: type=local,dest=/tmp/.build-cache,mode=max
@@ -158,6 +182,7 @@ jobs:
         with:
           name: debos-image
           path: /tmp
+
       - name: Load image
         run: |
           docker load --input /tmp/debos-image.tar
@@ -241,6 +266,7 @@ jobs:
         with:
           context: .
           push: true
+          platforms: ${{ env.DOCKER_TARGET_PLATFORMS }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           file: docker/Dockerfile
@@ -320,6 +346,7 @@ jobs:
         with:
           context: .
           push: true
+          platforms: ${{ env.DOCKER_TARGET_PLATFORMS }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           file: docker/Dockerfile

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,7 +3,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 ARG GOPATH=/usr/local/go
 
 ### first stage - builder ###
-FROM debian:bookworm-slim as builder
+FROM debian:bookworm-slim AS builder
 
 ARG DEBIAN_FRONTEND
 ARG GOPATH
@@ -34,7 +34,24 @@ COPY docker/get-archlinux-keyring.sh /
 RUN /get-archlinux-keyring.sh /arch-keyring
 
 ### second stage - runner ###
-FROM debian:bookworm-slim as runner
+FROM debian:bookworm-slim AS runner-amd64
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        linux-image-amd64 \
+        qemu-system-x86 \
+        user-mode-linux && \
+    rm -rf /var/lib/apt/lists/*
+
+FROM debian:bookworm-slim AS runner-arm64
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        linux-image-arm64 \
+        qemu-system-arm \
+        # fixes: qemu-system-aarch64: failed to find romfile "efi-virtio.rom"
+        ipxe-qemu && \
+    rm -rf /var/lib/apt/lists/*
+
+FROM runner-${TARGETARCH} AS runner
 
 ARG DEBIAN_FRONTEND
 ARG GOPATH
@@ -78,11 +95,9 @@ RUN apt-get update && \
         pigz \
         libostree-1-1 \
         libslirp-helper \
-        linux-image-amd64 \
         openssh-client \
         parted \
         pkg-config \
-        qemu-system-x86 \
         qemu-user-static \
         qemu-utils \
         rsync \
@@ -91,7 +106,6 @@ RUN apt-get update && \
         systemd-resolved \
         u-boot-tools \
         unzip \
-        user-mode-linux \
         xfsprogs \
         xz-utils \
         zip \


### PR DESCRIPTION
Follow-up of @tboehler1 's #505 as suggested by @obbardc 

Convert Dockerfile so multiple target architecturebuilds are possible. Also modify the CI pipeline, in order to built a single multi-platform container.

Note that at the current time-being docker cannot export multi-platform containers without an intermediate registry. Thus only the amd64 image is exported for the test stage. Nevertheless the arm64 image is built in the pipeline and also published later to the registry.

If the go-debos project has access to GitHub large runners, the pipeline could be reworked in order to build the container on a native arm runner. This would bring a significant speed improvement and also would allow for testing the arm container. But for know this solution should be sufficient as it tests the build on both architectures and runs the test suite on amd64.