### PR TITLE
actions: Add mmdebstrap action

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -151,7 +151,8 @@ jobs:
           - { name: "templating", case: "templating", variables: " -t escaped:\\$ba\\'d\\$gers\\ snakes" }
           - { name: "partitioning", case: "partitioning" }
           - { name: "msdos partitioning", case: "msdos" }
-          - { name: "debian (amd64)", case: "debian", variables: "-t architecture:amd64" }
+          - { name: "debian (amd64, debootstrap)", case: "debian", variables: "-t architecture:amd64" }
+          - { name: "debian (amd64, mmdebstrap)", case: "debian", variables: "-t architecture:amd64 -t tool:mmdebstrap" }
         exclude:
           - backend: nofakemachine
             test: { name: "partitioning", case: "partitioning" }
@@ -159,9 +160,13 @@ jobs:
             test: { name: "msdos partitioning", case: "msdos" }
         include:
           - backend: kvm
-            test: { name: "debian (arm64)", case: "debian", variables: "-t architecture:arm64" }
+            test: { name: "debian (arm64, debootstrap)", case: "debian", variables: "-t architecture:arm64" }
           - backend: kvm
-            test: { name: "debian (armhf)", case: "debian", variables: "-t architecture:armhf" }
+            test: { name: "debian (arm64, mmdebstrap)", case: "debian", variables: "-t architecture:arm64 -t tool:mmdebstrap" }
+          - backend: kvm
+            test: { name: "debian (armhf, debootstrap)", case: "debian", variables: "-t architecture:armhf" }
+          - backend: kvm
+            test: { name: "debian (armhf, mmdebstrap)", case: "debian", variables: "-t architecture:armhf -t tool:mmdebstrap" }
           - backend: kvm
             test: { name: "arch", case: "arch" }
           - backend: kvm

--- a/actions/mmdebstrap_action.go
+++ b/actions/mmdebstrap_action.go
@@ -17,6 +17,7 @@ and this may lead to incorrect configuration when becoming part of the created r
    keyring-files:
    include:
    dpkg-opts:
+   apt-opts:
 
 Mandatory properties:
 
@@ -45,6 +46,8 @@ Example:
 
 - dpkg-opts -- list of arbitrary options to dpkg.
 
+- apt-opts -- list of arbitrary options to apt.
+
 */
 package actions
 
@@ -69,6 +72,7 @@ type MmdebstrapAction struct {
 	MergedUsr        *bool `yaml:"merged-usr"`
 	Include          []string
 	DpkgOpts         []string `yaml:"dpkg-opts"`
+	AptOpts          []string `yaml:"apt-opts"`
 }
 
 func NewMmdebstrapAction() *MmdebstrapAction {
@@ -160,6 +164,12 @@ func (d *MmdebstrapAction) Run(context *debos.DebosContext) error {
 	if d.DpkgOpts != nil {
 		for _, opt := range d.DpkgOpts {
 			cmdline = append(cmdline, fmt.Sprintf("--dpkgopt='%s'", opt))
+		}
+	}
+
+	if d.AptOpts != nil {
+		for _, opt := range d.AptOpts {
+			cmdline = append(cmdline, fmt.Sprintf("--aptopt='%s'", opt))
 		}
 	}
 

--- a/actions/mmdebstrap_action.go
+++ b/actions/mmdebstrap_action.go
@@ -15,6 +15,7 @@ and this may lead to incorrect configuration when becoming part of the created r
    variant: "name"
    keyring-packages:
    keyring-files:
+   include:
 
 Mandatory properties:
 
@@ -39,6 +40,8 @@ Example:
 
 - merged-usr -- use merged '/usr' filesystem, fallback to distribution default if not set.
 
+- include -- list of packages to install during bootstrap.
+
 */
 package actions
 
@@ -61,6 +64,7 @@ type MmdebstrapAction struct {
 	KeyringFiles     []string `yaml:"keyring-files"`
 	Components       []string
 	MergedUsr        *bool `yaml:"merged-usr"`
+	Include          []string
 }
 
 func NewMmdebstrapAction() *MmdebstrapAction {
@@ -142,6 +146,11 @@ func (d *MmdebstrapAction) Run(context *debos.DebosContext) error {
 
 	if d.Variant != "" {
 		cmdline = append(cmdline, fmt.Sprintf("--variant=%s", d.Variant))
+	}
+
+	if d.Include != nil {
+		s := strings.Join(d.Include, ",")
+		cmdline = append(cmdline, fmt.Sprintf("--include=%s", s))
 	}
 
 	cmdline = append(cmdline, d.Suite)

--- a/actions/mmdebstrap_action.go
+++ b/actions/mmdebstrap_action.go
@@ -16,6 +16,7 @@ and this may lead to incorrect configuration when becoming part of the created r
    keyring-packages:
    keyring-files:
    include:
+   dpkg-opts:
 
 Mandatory properties:
 
@@ -42,6 +43,8 @@ Example:
 
 - include -- list of packages to install during bootstrap.
 
+- dpkg-opts -- list of arbitrary options to dpkg.
+
 */
 package actions
 
@@ -65,6 +68,7 @@ type MmdebstrapAction struct {
 	Components       []string
 	MergedUsr        *bool `yaml:"merged-usr"`
 	Include          []string
+	DpkgOpts         []string `yaml:"dpkg-opts"`
 }
 
 func NewMmdebstrapAction() *MmdebstrapAction {
@@ -151,6 +155,12 @@ func (d *MmdebstrapAction) Run(context *debos.DebosContext) error {
 	if d.Include != nil {
 		s := strings.Join(d.Include, ",")
 		cmdline = append(cmdline, fmt.Sprintf("--include=%s", s))
+	}
+
+	if d.DpkgOpts != nil {
+		for _, opt := range d.DpkgOpts {
+			cmdline = append(cmdline, fmt.Sprintf("--dpkgopt='%s'", opt))
+		}
 	}
 
 	cmdline = append(cmdline, d.Suite)

--- a/actions/mmdebstrap_action.go
+++ b/actions/mmdebstrap_action.go
@@ -1,0 +1,176 @@
+/*
+mmdebstrap Action
+
+Construct the target rootfs with mmdebstrap tool.
+
+Please keep in mind -- file `/etc/resolv.conf` will be removed after execution.
+Most of the OS scripts used by `mmdebstrap` copy `resolv.conf` from the host,
+and this may lead to incorrect configuration when becoming part of the created rootfs.
+
+ # Yaml syntax:
+ - action: mmdebstrap
+   mirrors: <list of URLs>
+   suite: "name"
+   components: <list of components>
+   variant: "name"
+   keyring-packages:
+   keyring-files:
+
+Mandatory properties:
+
+- suite -- release code name or symbolic name (e.g. "stable")
+
+Optional properties:
+
+- mirrors -- list of URLs with Debian-compatible repository
+ If no mirror is specified debos will use http://deb.debian.org/debian as default.
+
+- variant -- name of the bootstrap script variant to use
+
+- components -- list of components to use for packages selection.
+ If no components are specified debos will use main as default.
+
+Example:
+ components: [ main, contrib ]
+
+- keyring-packages -- list of keyrings for package validation.
+
+- keyring-files -- list keyring files for repository validation.
+
+- merged-usr -- use merged '/usr' filesystem, fallback to distribution default if not set.
+
+*/
+package actions
+
+import (
+	"fmt"
+	"os"
+	"path"
+	"strings"
+
+	"github.com/go-debos/debos"
+	"github.com/go-debos/fakemachine"
+)
+
+type MmdebstrapAction struct {
+	debos.BaseAction `yaml:",inline"`
+	Suite            string
+	Mirrors          []string
+	Variant          string
+	KeyringPackages  []string `yaml:"keyring-packages"`
+	KeyringFiles     []string `yaml:"keyring-files"`
+	Components       []string
+	MergedUsr        *bool `yaml:"merged-usr"`
+}
+
+func NewMmdebstrapAction() *MmdebstrapAction {
+	d := MmdebstrapAction{}
+	// Use main as default component
+	d.Components = []string{"main"}
+
+	return &d
+}
+
+func (d *MmdebstrapAction) listOptionFiles(context *debos.DebosContext) []string {
+	files := []string{}
+
+	if d.KeyringFiles != nil {
+		for _, file := range d.KeyringFiles {
+			file = debos.CleanPathAt(file, context.RecipeDir)
+			files = append(files, file)
+		}
+	}
+
+	return files
+}
+
+func (d *MmdebstrapAction) Verify(context *debos.DebosContext) error {
+	if len(d.Suite) == 0 {
+		return fmt.Errorf("suite property not specified")
+	}
+
+	files := d.listOptionFiles(context)
+
+	// Check if all needed files exists
+	for _, f := range files {
+		if _, err := os.Stat(f); os.IsNotExist(err) {
+			return err
+		}
+	}
+	return nil
+}
+
+func (d *MmdebstrapAction) PreMachine(context *debos.DebosContext, m *fakemachine.Machine, args *[]string) error {
+
+	mounts := d.listOptionFiles(context)
+
+	// Mount configuration files outside of recipes directory
+	for _, mount := range mounts {
+		m.AddVolume(path.Dir(mount))
+	}
+
+	return nil
+}
+
+func (d *MmdebstrapAction) Run(context *debos.DebosContext) error {
+	cmdline := []string{"mmdebstrap"}
+
+	if d.MergedUsr != nil {
+		if *d.MergedUsr {
+			cmdline = append(cmdline, "--hook-dir=/usr/share/mmdebstrap/hooks/merged-usr")
+		} else {
+			cmdline = append(cmdline, "--hook-dir=/usr/share/mmdebstrap/hooks/no-merged-usr")
+		}
+	}
+
+	if d.KeyringFiles != nil {
+		s := strings.Join(d.KeyringFiles, ",")
+		cmdline = append(cmdline, fmt.Sprintf("--keyring=%s", s))
+	}
+
+	if d.KeyringPackages != nil {
+		s := strings.Join(d.KeyringPackages, ",")
+		cmdline = append(cmdline, fmt.Sprintf("--include=%s", s))
+	}
+
+	if d.Components != nil {
+		s := strings.Join(d.Components, ",")
+		cmdline = append(cmdline, fmt.Sprintf("--components=%s", s))
+	}
+
+	cmdline = append(cmdline, fmt.Sprintf("--architectures=%s", context.Architecture))
+
+	if d.Variant != "" {
+		cmdline = append(cmdline, fmt.Sprintf("--variant=%s", d.Variant))
+	}
+
+	cmdline = append(cmdline, d.Suite)
+	cmdline = append(cmdline, context.Rootdir)
+
+	if d.Mirrors != nil {
+		cmdline = append(cmdline, d.Mirrors...)
+	}
+
+	/* Make sure files in /etc/apt/ exist inside the fakemachine otherwise
+	   mmdebstrap prints a warning about the path not existing. */
+	if fakemachine.InMachine() {
+		if err := os.MkdirAll(path.Join("/etc/apt/apt.conf.d"), os.ModePerm); err != nil {
+			return err
+		}
+		if err := os.MkdirAll(path.Join("/etc/apt/trusted.gpg.d"), os.ModePerm); err != nil {
+			return err
+		}
+	}
+
+	mmdebstrapErr := debos.Command{}.Run("Mmdebstrap", cmdline...)
+
+	/* Cleanup resolv.conf after mmdebstrap */
+	resolvconf := path.Join(context.Rootdir, "/etc/resolv.conf")
+	if _, err := os.Stat(resolvconf); !os.IsNotExist(err) {
+		if err = os.Remove(resolvconf); err != nil {
+			return err
+		}
+	}
+
+	return mmdebstrapErr
+}

--- a/actions/recipe.go
+++ b/actions/recipe.go
@@ -49,6 +49,8 @@ Supported actions
 
 - debootstrap -- https://godoc.org/github.com/go-debos/debos/actions#hdr-Debootstrap_Action
 
+- mmdebstrap -- https://godoc.org/github.com/go-debos/debos/actions#hdr-Mmdebstrap_Action
+
 - download -- https://godoc.org/github.com/go-debos/debos/actions#hdr-Download_Action
 
 - filesystem-deploy -- https://godoc.org/github.com/go-debos/debos/actions#hdr-FilesystemDeploy_Action
@@ -115,6 +117,8 @@ func (y *YamlAction) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	switch aux.Action {
 	case "debootstrap":
 		y.Action = NewDebootstrapAction()
+	case "mmdebstrap":
+		y.Action = NewMmdebstrapAction()
 	case "pacstrap":
 		y.Action = &PacstrapAction{}
 	case "pack":

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -85,6 +85,7 @@ RUN apt-get update && \
         ca-certificates \
         debian-ports-archive-keyring \
         debootstrap \
+        mmdebstrap \
         dosfstools \
         e2fsprogs \
         equivs \
@@ -112,7 +113,8 @@ RUN apt-get update && \
         zstd \
         makepkg \
         pacman-package-manager \
-        arch-install-scripts && \
+        arch-install-scripts \
+        arch-test && \
     rm -rf /var/lib/apt/lists/*
 
 # debian's qemu-user-static package no longer registers binfmts

--- a/tests/debian/test.yaml
+++ b/tests/debian/test.yaml
@@ -1,9 +1,10 @@
 ---
 {{- $architecture := or .architecture "amd64"}}
+{{- $tool := or .tool "debootstrap" }}
 architecture: {{$architecture}}
 
 actions:
-  - action: debootstrap
+  - action: {{ $tool }}
     suite: bullseye
     variant: minbase
     merged-usr: true

--- a/tests/debian/test.yaml
+++ b/tests/debian/test.yaml
@@ -1,11 +1,12 @@
 ---
 {{- $architecture := or .architecture "amd64"}}
+{{- $suite := or .suite "bookworm"}}
 {{- $tool := or .tool "debootstrap" }}
 architecture: {{$architecture}}
 
 actions:
   - action: {{ $tool }}
-    suite: bullseye
+    suite: {{ $suite }}
     variant: minbase
     merged-usr: true
 


### PR DESCRIPTION
Add mmdebstrap [1] as a faster and more flexible alternative to debootstrap.

[1] https://gitlab.mister-muffin.de/josch/mmdebstrap

I am not really familar with go (day to day language is Python or C). Therefore I ask for your patience :-)

# Comparison to deboostrap

Example recipe on a Raspberry Pi 5 in docker container with KVM enabled:
```
---
{{- $architecture := or .architecture "arm64"}}
{{- $tool := or .tool "mmdebstrap" }}
architecture: {{$architecture}}

actions:
  - action: {{ $tool }}
    suite: bookworm
    variant: minbase

  - action: apt
    description: Install some base packages
    packages:
      - procps
```

With `deboostrap`:
```
real    0m53.590s
user    0m38.792s
sys     0m25.345s

```

With `mmdebstrap`:
```
real    0m33.400s
user    0m24.239s
sys     0m8.838s
```

=> 20 seconds faster. I plan to build a kinda build-on-demand service around debos, so every second matters :smile: 