### PR TITLE
cmd: Add 'version' option

### DIFF
--- a/cmd/debos/debos.go
+++ b/cmd/debos/debos.go
@@ -15,6 +15,8 @@ import (
 	"github.com/jessevdk/go-flags"
 )
 
+const Version = "1.1.4"
+
 func checkError(context *debos.DebosContext, err error, a debos.Action, stage string) int {
 	if err == nil {
 		return 0
@@ -75,6 +77,7 @@ func main() {
 		PrintRecipe   bool              `long:"print-recipe" description:"Print final recipe"`
 		DryRun        bool              `long:"dry-run" description:"Compose final recipe to build but without any real work started"`
 		DisableFakeMachine bool         `long:"disable-fakemachine" description:"Do not use fakemachine."`
+		Version       bool              `long:"version" description:"Print debos version"`
 	}
 
 	// These are the environment variables that will be detected on the
@@ -108,6 +111,11 @@ func main() {
 			exitcode = 1
 			return
 		}
+	}
+
+	if options.Version {
+		fmt.Printf("debos v%s\n", Version)
+		return
 	}
 
 	if len(args) != 1 {


### PR DESCRIPTION
This 'version' option prints the debos version. Fix: #430