### PR TITLE
ImagePartitionAction: retry losetup.Attach()

### DIFF
--- a/actions/image_partition_action.go
+++ b/actions/image_partition_action.go
@@ -471,7 +471,7 @@ func (i *ImagePartitionAction) PreNoMachine(context *debos.DebosContext) error {
 	}
 
 	if err != nil {
-		return fmt.Errorf("Failed to setup loop device")
+		return fmt.Errorf("Failed to setup loop device: %v", err)
 	}
 	context.Image = i.loopDev.Path()
 	i.usingLoop = true


### PR DESCRIPTION
losetup.Attach() can fail due to concurrent attaches in other processes as seen in https://github.com/go-debos/debos/issues/522 .

The problem is a race condition between finding a free loop device and attaching the image.

Now that we have go-losetup v2, which does report the error, we can do what util-linux does
( https://github.com/util-linux/util-linux/blob/4c4b248c68149089c8be2f830214bb2be693307e/sys-utils/losetup.c#L662 ) and retry on failure.

I only sleep for 200 ms as opposed to 1 second as in https://github.com/go-debos/debos/blob/78aad24dc068ec2aac0355c165f760b953379b8f/actions/image_partition_action.go#L668 because the race condition should immediately resolve without waiting at all.

I still sleep for 200 ms as this is what util-linux does to prevent spinning ( https://github.com/util-linux/util-linux/commit/3ff6fb802de1efafbd90af228f91461691ac190c ).

Fixes: https://github.com/go-debos/debos/issues/522