### PR TITLE
README: use relative link to docker/README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ An official debos container is available:
 docker pull godebos/debos
 ```
 
-See [docker/README.md](https://github.com/go-debos/debos/blob/master/docker/README.md) for usage.
+See [docker/README.md](docker/README.md) for usage.
 
 ## Installation from source (under Debian)
 


### PR DESCRIPTION
This fix the link since the default branch name has changed. Fix #520