### PR TITLE
Fix mmdebstrap action

### DIFF
--- a/actions/mmdebstrap_action.go
+++ b/actions/mmdebstrap_action.go
@@ -163,13 +163,13 @@ func (d *MmdebstrapAction) Run(context *debos.DebosContext) error {
 
 	if d.DpkgOpts != nil {
 		for _, opt := range d.DpkgOpts {
-			cmdline = append(cmdline, fmt.Sprintf("--dpkgopt='%s'", opt))
+			cmdline = append(cmdline, fmt.Sprintf("--dpkgopt=%s", opt))
 		}
 	}
 
 	if d.AptOpts != nil {
 		for _, opt := range d.AptOpts {
-			cmdline = append(cmdline, fmt.Sprintf("--aptopt='%s'", opt))
+			cmdline = append(cmdline, fmt.Sprintf("--aptopt=%s", opt))
 		}
 	}
 

--- a/tests/debian/test.yaml
+++ b/tests/debian/test.yaml
@@ -9,6 +9,12 @@ actions:
     suite: {{ $suite }}
     variant: minbase
     merged-usr: true
+{{- if eq $tool "mmdebstrap" }}
+    dpkg-opts:
+      - path-exclude=/usr/share/man/*
+    apt-opts:
+      - Apt::Install-Recommends "true"
+{{- end }}
 
   - action: apt
     description: Install some base packages


### PR DESCRIPTION
The mmdebstrap process fails because the format contains single quotation.
To fix this, remove single quotation (') from the append strings of dpkgopt and aptopt.

Debos yaml file:
```
architecture: amd64

actions:
  - action: mmdebstrap
    suite: sid
    variant: minbase
    merged-usr: true
    dpkg-opts:
      - path-exclude=/usr/share/man/*
```

Error message:
```
[...]
2025/03/03 06:59:12 Mmdebstrap | dpkg: error: configuration error: /etc/dpkg/dpkg.cfg.d/99mmdebstrap:1: unknown option ''
[...]
```

From debug message of mmdebstrap:
```
[...]
D: 1 3180 content of /etc/dpkg/dpkg.cfg.d/99mmdebstrap:
'path-exclude=/usr/share/man/*' <--here
apt 2.9.30 (amd64)
Supported modules:
*Ver: Standard .deb
[...]
```