### PR TITLE
tests: arch: remove deprecated repositories

### DIFF
--- a/tests/arch/pacman.conf
+++ b/tests/arch/pacman.conf
@@ -78,12 +78,6 @@ Include = /etc/pacman.d/mirrorlist
 [extra]
 Include = /etc/pacman.d/mirrorlist
 
-#[community-testing]
-#Include = /etc/pacman.d/mirrorlist
-
-[community]
-Include = /etc/pacman.d/mirrorlist
-
 # If you want to run 32 bit applications on your x86_64 system,
 # enable the multilib repositories as required here.
 


### PR DESCRIPTION
The community repositories were merged into extra around to years ago. Recently the database files got cleaned up on the mirrors, causing errors in CI. Adjust pacman.conf to remove these deprecated repositories

See https://archlinux.org/news/cleaning-up-old-repositories/ for more details