### PR TITLE
Revert "cmd: Add 'version' option"

### DIFF
--- a/cmd/debos/debos.go
+++ b/cmd/debos/debos.go
@@ -15,8 +15,6 @@ import (
 	"github.com/jessevdk/go-flags"
 )
 
-const Version = "1.1.4"
-
 func checkError(context *debos.DebosContext, err error, a debos.Action, stage string) int {
 	if err == nil {
 		return 0
@@ -77,7 +75,6 @@ func main() {
 		PrintRecipe   bool              `long:"print-recipe" description:"Print final recipe"`
 		DryRun        bool              `long:"dry-run" description:"Compose final recipe to build but without any real work started"`
 		DisableFakeMachine bool         `long:"disable-fakemachine" description:"Do not use fakemachine."`
-		Version       bool              `long:"version" description:"Print debos version"`
 	}
 
 	// These are the environment variables that will be detected on the
@@ -111,11 +108,6 @@ func main() {
 			exitcode = 1
 			return
 		}
-	}
-
-	if options.Version {
-		fmt.Printf("debos v%s\n", Version)
-		return
 	}
 
 	if len(args) != 1 {


### PR DESCRIPTION
The original commit adds a --version argument to debos but the version is hardcoded which is a bit awkward. Since we haven't shipped this commit in a release yet, revert it to allow the proper implementation to be completed in the next version of debos.

This reverts commit f13268b17345065d3f17397b66046d913a540a10.