### PR TITLE
Add configurable default chroot method

### DIFF
--- a/action.go
+++ b/action.go
@@ -42,6 +42,7 @@ type DebosContext struct {
 	*CommonContext
 	RecipeDir       string
 	Architecture    string
+	ChrootMethod    ChrootEnterMethod
 	SectorSize      int
 }
 

--- a/cmd/debos/debos.go
+++ b/cmd/debos/debos.go
@@ -50,37 +50,36 @@ func warnLocalhost(variable string, value string) {
 		    Consider using an address that is valid on your network.`
 
 	if strings.Contains(value, "localhost") ||
-	   strings.Contains(value, "127.0.0.1") ||
-	   strings.Contains(value, "::1") {
+		strings.Contains(value, "127.0.0.1") ||
+		strings.Contains(value, "::1") {
 		log.Printf(message, variable)
 	}
 }
 
-
 func main() {
-	context := debos.DebosContext { &debos.CommonContext{}, "", "", 512 }
 	var options struct {
-		Backend       string            `short:"b" long:"fakemachine-backend" description:"Fakemachine backend to use" default:"auto"`
-		ArtifactDir   string            `long:"artifactdir" description:"Directory for packed archives and ostree repositories (default: current directory)"`
-		InternalImage string            `long:"internal-image" hidden:"true"`
-		TemplateVars  map[string]string `short:"t" long:"template-var" description:"Template variables (use -t VARIABLE:VALUE syntax)"`
-		DebugShell    bool              `long:"debug-shell" description:"Fall into interactive shell on error"`
-		Shell         string            `short:"s" long:"shell" description:"Redefine interactive shell binary (default: bash)" optionsl:"" default:"/bin/bash"`
-		ScratchSize   string            `long:"scratchsize" description:"Size of disk-backed scratch space (parsed with human-readable suffix; assumed bytes if no suffix)"`
-		CPUs          int               `short:"c" long:"cpus" description:"Number of CPUs to use for build VM (default: 2)"`
-		Memory        string            `short:"m" long:"memory" description:"Amount of memory for build VM (parsed with human-readable suffix; assumed bytes if no suffix. default: 2Gb)"`
-		ShowBoot      bool              `long:"show-boot" description:"Show boot/console messages from the fake machine"`
-		EnvironVars   map[string]string `short:"e" long:"environ-var" description:"Environment variables (use -e VARIABLE:VALUE syntax)"`
-		Verbose       bool              `short:"v" long:"verbose" description:"Verbose output"`
-		PrintRecipe   bool              `long:"print-recipe" description:"Print final recipe"`
-		DryRun        bool              `long:"dry-run" description:"Compose final recipe to build but without any real work started"`
-		DisableFakeMachine bool         `long:"disable-fakemachine" description:"Do not use fakemachine."`
+		Backend            string            `short:"b" long:"fakemachine-backend" description:"Fakemachine backend to use" default:"auto"`
+		ArtifactDir        string            `long:"artifactdir" description:"Directory for packed archives and ostree repositories (default: current directory)"`
+		InternalImage      string            `long:"internal-image" hidden:"true"`
+		TemplateVars       map[string]string `short:"t" long:"template-var" description:"Template variables (use -t VARIABLE:VALUE syntax)"`
+		DebugShell         bool              `long:"debug-shell" description:"Fall into interactive shell on error"`
+		Shell              string            `short:"s" long:"shell" description:"Redefine interactive shell binary (default: bash)" optionsl:"" default:"/bin/bash"`
+		ScratchSize        string            `long:"scratchsize" description:"Size of disk-backed scratch space (parsed with human-readable suffix; assumed bytes if no suffix)"`
+		CPUs               int               `short:"c" long:"cpus" description:"Number of CPUs to use for build VM (default: 2)"`
+		Memory             string            `short:"m" long:"memory" description:"Amount of memory for build VM (parsed with human-readable suffix; assumed bytes if no suffix. default: 2Gb)"`
+		ShowBoot           bool              `long:"show-boot" description:"Show boot/console messages from the fake machine"`
+		EnvironVars        map[string]string `short:"e" long:"environ-var" description:"Environment variables (use -e VARIABLE:VALUE syntax)"`
+		Verbose            bool              `short:"v" long:"verbose" description:"Verbose output"`
+		PrintRecipe        bool              `long:"print-recipe" description:"Print final recipe"`
+		DryRun             bool              `long:"dry-run" description:"Compose final recipe to build but without any real work started"`
+		DisableFakeMachine bool              `long:"disable-fakemachine" description:"Do not use fakemachine."`
+		ChrootMethod       string            `long:"default-chroot-method" description:"Change the default chroot method. default: nspawn"`
 	}
 
 	// These are the environment variables that will be detected on the
 	// host and propagated to fakemachine. These are listed lower case, but
 	// they are detected and configured in both lower case and upper case.
-	var environ_vars = [...]string {
+	var environ_vars = [...]string{
 		"http_proxy",
 		"https_proxy",
 		"ftp_proxy",
@@ -98,6 +97,8 @@ func main() {
 	parser := flags.NewParser(&options, flags.Default)
 	fakemachineBackends := parser.FindOptionByLongName("fakemachine-backend")
 	fakemachineBackends.Choices = fakemachine.BackendNames()
+	defaultChrootMethods := parser.FindOptionByLongName("default-chroot-method")
+	defaultChrootMethods.Choices = debos.ChrootMethodsString()
 
 	args, err := parser.Parse()
 	if err != nil {
@@ -120,6 +121,26 @@ func main() {
 		log.Println("--disable-fakemachine and --fakemachine-backend are mutually exclusive")
 		exitcode = 1
 		return
+	}
+
+	var chrootMethod debos.ChrootEnterMethod
+	if options.ChrootMethod == "" {
+		chrootMethod = debos.CHROOT_METHOD_NSPAWN
+	} else {
+		chrootMethod, err = debos.ChrootMethodFromString(options.ChrootMethod)
+		if err != nil {
+			fmt.Fprintf(os.Stderr,
+				"Unable to convert string to chroot method: %s\n", err)
+			exitcode = 1
+			return
+		}
+	}
+	context := debos.DebosContext{
+		CommonContext: &debos.CommonContext{},
+		RecipeDir:     "",
+		Architecture:  "",
+		ChrootMethod:  chrootMethod,
+		SectorSize:    512,
 	}
 
 	// Set interactive shell binary only if '--debug-shell' options passed


### PR DESCRIPTION
By default debos runs chroot commands using systemd-nspawn. This hasn't been configurable. In order for systems that don't have systemd-nspawn to be able to build images with recipes using the chroot keyword for run actions using debos, the default chroot method must be configurable. Since systemd-nspawn is an improved version of chroot, just using a chroot instead should work fine.

Expose a command line option "--default-chroot-method" that allows setting the default method to one that isn't systemd-nspawn.