### PR TITLE
Add qemu mapping for sh4 architecture

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -327,6 +327,10 @@ func newQemuHelper(c Command) (*qemuHelper, error) {
 		if runtime.GOARCH != "amd64" {
 			q.qemusrc = "/usr/bin/qemu-x86_64-static"
 		}
+	case "sh4":
+		if runtime.GOARCH != "sh4" {
+			q.qemusrc = "/usr/bin/qemu-sh4-static"
+		}
 	default:
 		return nil, fmt.Errorf("Don't know qemu for architecture %s", c.Architecture)
 	}


### PR DESCRIPTION
Was getting an error about not knowing the correct qemu executable. Testing using the SH4 Debian Port (http://deb.debian.org/debian-ports/)