### PR TITLE
docker: use the new format for declaring labels

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -60,10 +60,10 @@ ARG GOPATH
 # Set HOME to a writable directory in case something wants to cache things
 ENV HOME=/tmp
 
-LABEL org.label-schema.name "debos"
-LABEL org.label-schema.description "Debian OS builder"
-LABEL org.label-schema.vcs-url = "https://github.com/go-debos/debos"
-LABEL org.label-schema.docker.cmd 'docker run \
+LABEL org.label-schema.name="debos"
+LABEL org.label-schema.description="Debian OS builder"
+LABEL org.label-schema.vcs-url="https://github.com/go-debos/debos"
+LABEL org.label-schema.docker.cmd='docker run \
   --rm \
   --interactive \
   --tty \


### PR DESCRIPTION
See: https://docs.docker.com/reference/build-checks/legacy-key-value-format/

This should remove warnings from github.