### PR TITLE
actions: make run action fail if a command fails

### DIFF
--- a/actions/run_action.go
+++ b/actions/run_action.go
@@ -140,7 +140,7 @@ func (run *RunAction) doRun(context debos.DebosContext) error {
 	}
 
 	// Command/script with options passed as single string
-	cmdline = append([]string{"sh", "-c"}, cmdline...)
+	cmdline = append([]string{"sh", "-e", "-c"}, cmdline...)
 
 	if !run.Chroot {
 		cmd.AddEnvKey("RECIPEDIR", context.RecipeDir)


### PR DESCRIPTION
Passing -e to sh makes the action to fail immediately instead of continuing to the next commands.

Fixes: #290

With the reproducer `fail.yaml`:
```
actions:
  - action: run
    description: Hello world
    chroot: false
    command: |
      false
      echo "Prior command failed, yet execution continues..."
```
The result was:
```
$ debos fail.yaml 
2025/08/07 09:48:27 ==== Hello world ====
2025/08/07 09:48:27 false... | Prior command failed, yet execution continues...
2025/08/07 11:48:28 ==== Recipe done ====
```
And with this fix:
```
$ debos fail.yaml 
2025/08/07 09:49:00 ==== Hello world ====
2025/08/07 09:49:00 Action `Hello world` failed at stage Run, error: exit status 1
2025/08/07 11:49:01 fakemachine failed with non-zero exitcode: 1
```