### PR TITLE
Run CI tests under debian-forky

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,6 +25,7 @@ jobs:
           - arch
           - bookworm
           - trixie
+          - forky
     runs-on: ubuntu-latest
     defaults:
       run:


### PR DESCRIPTION
Since forky is the codename for the new version of debian testing, run the CI tests under forky.