### PR TITLE
Remove user-mode-linux support from container & remove related tests 

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -162,7 +162,6 @@ jobs:
         backend:
           - nofakemachine
           - qemu
-          - uml
           - kvm
         test:
           - { name: "recipes", case: "recipes" }

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -39,8 +39,7 @@ FROM debian:bookworm-slim AS runner-amd64
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
         linux-image-amd64 \
-        qemu-system-x86 \
-        user-mode-linux && \
+        qemu-system-x86 && \
     rm -rf /var/lib/apt/lists/*
 
 FROM debian:bookworm-slim AS runner-arm64
@@ -96,7 +95,6 @@ RUN apt-get update && \
         gzip \
         pigz \
         libostree-1-1 \
-        libslirp-helper \
         openssh-client \
         parted \
         pkg-config \

--- a/tests/exit_test/exit_test.sh
+++ b/tests/exit_test/exit_test.sh
@@ -54,20 +54,20 @@ fi
 expect_success debos --help
 expect_failure debos --not-a-valid-option
 expect_failure debos
-expect_failure debos good.yaml good.yaml
+expect_failure debos --fakemachine-backend=qemu good.yaml good.yaml
 expect_failure debos --disable-fakemachine --fakemachine-backend=qemu good.yaml
-expect_failure debos non-existent-file.yaml
-expect_failure debos garbled.yaml
+expect_failure debos --fakemachine-backend=qemu non-existent-file.yaml
+expect_failure debos --fakemachine-backend=qemu garbled.yaml
 expect_failure debos --fakemachine-backend=kvm good.yaml
-expect_failure debos verify-fail.yaml
-expect_success debos --dry-run good.yaml
-expect_failure debos --memory=NotANumber good.yaml
-expect_failure debos --scratchsize=NotANumber good.yaml
-expect_success debos good.yaml
-expect_failure debos bad.yaml
-expect_failure debos pre-machine-failure.yaml
-expect_failure debos post-machine-failure.yaml
-expect_failure rename_command NOT_DEBOS debos good.yaml
+expect_failure debos --fakemachine-backend=qemu verify-fail.yaml
+expect_success debos --fakemachine-backend=qemu --dry-run good.yaml
+expect_failure debos --fakemachine-backend=qemu --memory=NotANumber good.yaml
+expect_failure debos --fakemachine-backend=qemu --scratchsize=NotANumber good.yaml
+expect_success debos --fakemachine-backend=qemu good.yaml
+expect_failure debos --fakemachine-backend=qemu bad.yaml
+expect_failure debos --fakemachine-backend=qemu pre-machine-failure.yaml
+expect_failure debos --fakemachine-backend=qemu post-machine-failure.yaml
+expect_failure rename_command NOT_DEBOS debos --fakemachine-backend=qemu good.yaml
 
 expect_failure $SUDO debos non-existent-file.yaml --disable-fakemachine
 expect_failure $SUDO debos garbled.yaml --disable-fakemachine

--- a/tests/exit_test/exit_test.sh
+++ b/tests/exit_test/exit_test.sh
@@ -55,7 +55,7 @@ expect_success debos --help
 expect_failure debos --not-a-valid-option
 expect_failure debos
 expect_failure debos good.yaml good.yaml
-expect_failure debos --disable-fakemachine --fakemachine-backend=uml good.yaml
+expect_failure debos --disable-fakemachine --fakemachine-backend=qemu good.yaml
 expect_failure debos non-existent-file.yaml
 expect_failure debos garbled.yaml
 expect_failure debos --fakemachine-backend=kvm good.yaml


### PR DESCRIPTION
Since we plan to remove user-mode-linux support from fakemachine (see https://github.com/go-debos/fakemachine/issues/193); don't install the packages in the container & don't run the user-mode-linux tests in CI.

Depends on https://github.com/go-debos/fakemachine/pull/244