### PR TITLE
Misc static analysis fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,26 +1,31 @@
 # debos command
 /debos
 
-# Created by https://www.gitignore.io/api/vim,linux,go
+# Created by https://www.toptal.com/developers/gitignore/api/go,linux,vim
+# Edit at https://www.toptal.com/developers/gitignore?templates=go,linux,vim
 
 ### Go ###
+# If you prefer the allow list template instead of the deny list, see community template:
+# https://github.com/github/gitignore/blob/main/community/Golang/Go.AllowList.gitignore
+#
 # Binaries for programs and plugins
 *.exe
+*.exe~
 *.dll
 *.so
 *.dylib
 
-# Test binary, build with `go test -c`
+# Test binary, built with `go test -c`
 *.test
 
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
 
-# Project-local glide cache, RE: https://github.com/Masterminds/glide/issues/736
-.glide/
+# Dependency directories (remove the comment below to include it)
+# vendor/
 
-# Golang project vendor packages which should be ignored
-vendor/
+# Go workspace file
+go.work
 
 ### Linux ###
 *~
@@ -38,16 +43,23 @@ vendor/
 .nfs*
 
 ### Vim ###
-# swap
+# Swap
 [._]*.s[a-v][a-z]
+!*.svg  # comment out if you don't need vector files
 [._]*.sw[a-p]
-[._]s[a-v][a-z]
+[._]s[a-rt-v][a-z]
+[._]ss[a-gi-z]
 [._]sw[a-p]
-# session
-Session.vim
-# temporary
-.netrwhist
-# auto-generated tag files
-tags
 
-# End of https://www.gitignore.io/api/vim,linux,go
+# Session
+Session.vim
+Sessionx.vim
+
+# Temporary
+.netrwhist
+# Auto-generated tag files
+tags
+# Persistent undo
+[._]*.un~
+
+# End of https://www.toptal.com/developers/gitignore/api/go,linux,vim

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+# debos command
+/debos
 
 # Created by https://www.gitignore.io/api/vim,linux,go
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,8 @@
 # debos command
 /debos
 
-# Created by https://www.toptal.com/developers/gitignore/api/go,linux,vim
-# Edit at https://www.toptal.com/developers/gitignore?templates=go,linux,vim
+# Created by https://www.toptal.com/developers/gitignore/api/go,linux,vim,visualstudiocode
+# Edit at https://www.toptal.com/developers/gitignore?templates=go,linux,vim,visualstudiocode
 
 ### Go ###
 # If you prefer the allow list template instead of the deny list, see community template:
@@ -62,4 +62,23 @@ tags
 # Persistent undo
 [._]*.un~
 
-# End of https://www.toptal.com/developers/gitignore/api/go,linux,vim
+### VisualStudioCode ###
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+!.vscode/*.code-snippets
+
+# Local History for Visual Studio Code
+.history/
+
+# Built Visual Studio Code Extensions
+*.vsix
+
+### VisualStudioCode Patch ###
+# Ignore all local history of files
+.history
+.ionide
+
+# End of https://www.toptal.com/developers/gitignore/api/go,linux,vim,visualstudiocode

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,8 @@
 version: "2"
 linters:
   default: none
+  enable:
+    - staticcheck
 formatters:
   enable:
     - gofmt

--- a/actions/debootstrap_action.go
+++ b/actions/debootstrap_action.go
@@ -192,7 +192,7 @@ func (d *DebootstrapAction) Run(context *debos.DebosContext) error {
 	}
 
 	if !d.CheckGpg {
-		cmdline = append(cmdline, fmt.Sprintf("--no-check-gpg"))
+		cmdline = append(cmdline, "--no-check-gpg")
 	} else if d.KeyringFile != "" {
 		cmdline = append(cmdline, fmt.Sprintf("--keyring=%s", d.KeyringFile))
 	}

--- a/actions/download_action.go
+++ b/actions/download_action.go
@@ -115,7 +115,7 @@ func (d *DownloadAction) Verify(context *debos.DebosContext) error {
 	if err != nil {
 		return err
 	}
-	if d.Unpack == true {
+	if d.Unpack {
 		if _, err := d.archive(filename); err != nil {
 			return err
 		}
@@ -147,7 +147,7 @@ func (d *DownloadAction) Run(context *debos.DebosContext) error {
 		return fmt.Errorf("unsupported URL provided: '%s'", url.String())
 	}
 
-	if d.Unpack == true {
+	if d.Unpack {
 		archive, err := d.archive(filename)
 		if err != nil {
 			return err

--- a/actions/download_action.go
+++ b/actions/download_action.go
@@ -63,7 +63,7 @@ func (d *DownloadAction) validateUrl() (*url.URL, error) {
 	case "http", "https":
 		// Supported scheme
 	default:
-		return url, fmt.Errorf("Unsupported URL is provided: '%s'", url.String())
+		return url, fmt.Errorf("unsupported URL provided: '%s'", url.String())
 	}
 
 	return url, nil
@@ -77,7 +77,7 @@ func (d *DownloadAction) validateFilename(context *debos.DebosContext, url *url.
 		filename = path.Base(d.Filename)
 	}
 	if len(filename) == 0 || filename == "." || filename == "/" {
-		return "", fmt.Errorf("Incorrect filename is provided for '%s'", d.Url)
+		return "", fmt.Errorf("incorrect filename provided for '%s'", d.Url)
 	}
 	filename = path.Join(context.Scratchdir, filename)
 	return filename, nil
@@ -104,7 +104,7 @@ func (d *DownloadAction) Verify(context *debos.DebosContext) error {
 	var filename string
 
 	if len(d.Name) == 0 {
-		return fmt.Errorf("Property 'name' is mandatory for download action\n")
+		return fmt.Errorf("property 'name' is mandatory for download action")
 	}
 
 	url, err := d.validateUrl()
@@ -144,7 +144,7 @@ func (d *DownloadAction) Run(context *debos.DebosContext) error {
 			return err
 		}
 	default:
-		return fmt.Errorf("Unsupported URL is provided: '%s'", url.String())
+		return fmt.Errorf("unsupported URL provided: '%s'", url.String())
 	}
 
 	if d.Unpack == true {

--- a/actions/filesystem_deploy_action.go
+++ b/actions/filesystem_deploy_action.go
@@ -31,7 +31,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 	"path"
@@ -93,7 +92,7 @@ func (fd *FilesystemDeployAction) setupKernelCmdline(context *debos.DebosContext
 		return fmt.Errorf("couldn't create etc/kernel in image: %v", err)
 	}
 	path := path.Join(context.Rootdir, "etc/kernel/cmdline")
-	current, _ := ioutil.ReadFile(path)
+	current, _ := os.ReadFile(path)
 	f, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE, 0755)
 	defer f.Close()
 

--- a/actions/filesystem_deploy_action.go
+++ b/actions/filesystem_deploy_action.go
@@ -67,11 +67,10 @@ func (fd *FilesystemDeployAction) setupFSTab(context *debos.DebosContext) error 
 
 	fstab := path.Join(context.Rootdir, "etc/fstab")
 	f, err := os.OpenFile(fstab, os.O_RDWR|os.O_CREATE, 0755)
-	defer f.Close()
-
 	if err != nil {
 		return fmt.Errorf("couldn't open /etc/fstab: %v", err)
 	}
+	defer f.Close()
 
 	_, err = io.Copy(f, &context.ImageFSTab)
 
@@ -94,11 +93,10 @@ func (fd *FilesystemDeployAction) setupKernelCmdline(context *debos.DebosContext
 	path := path.Join(context.Rootdir, "etc/kernel/cmdline")
 	current, _ := os.ReadFile(path)
 	f, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE, 0755)
-	defer f.Close()
-
 	if err != nil {
 		return fmt.Errorf("couldn't open /etc/kernel/cmdline: %v", err)
 	}
+	defer f.Close()
 
 	cmdline = append(cmdline, strings.TrimSpace(string(current)))
 	cmdline = append(cmdline, context.ImageKernelRoot)

--- a/actions/filesystem_deploy_action.go
+++ b/actions/filesystem_deploy_action.go
@@ -56,14 +56,14 @@ func NewFilesystemDeployAction() *FilesystemDeployAction {
 
 func (fd *FilesystemDeployAction) setupFSTab(context *debos.DebosContext) error {
 	if context.ImageFSTab.Len() == 0 {
-		return errors.New("Fstab not generated, missing image-partition action?")
+		return errors.New("fstab not generated, missing image-partition action?")
 	}
 
 	log.Print("Setting up /etc/fstab")
 
 	err := os.MkdirAll(path.Join(context.Rootdir, "etc"), 0755)
 	if err != nil {
-		return fmt.Errorf("Couldn't create etc in image: %v", err)
+		return fmt.Errorf("couldn't create etc in image: %v", err)
 	}
 
 	fstab := path.Join(context.Rootdir, "etc/fstab")
@@ -71,13 +71,13 @@ func (fd *FilesystemDeployAction) setupFSTab(context *debos.DebosContext) error 
 	defer f.Close()
 
 	if err != nil {
-		return fmt.Errorf("Couldn't open /etc/fstab: %v", err)
+		return fmt.Errorf("couldn't open /etc/fstab: %v", err)
 	}
 
 	_, err = io.Copy(f, &context.ImageFSTab)
 
 	if err != nil {
-		return fmt.Errorf("Couldn't write /etc/fstab: %v", err)
+		return fmt.Errorf("couldn't write /etc/fstab: %v", err)
 	}
 
 	return nil
@@ -90,7 +90,7 @@ func (fd *FilesystemDeployAction) setupKernelCmdline(context *debos.DebosContext
 
 	err := os.MkdirAll(path.Join(context.Rootdir, "etc", "kernel"), 0755)
 	if err != nil {
-		return fmt.Errorf("Couldn't create etc/kernel in image: %v", err)
+		return fmt.Errorf("couldn't create etc/kernel in image: %v", err)
 	}
 	path := path.Join(context.Rootdir, "etc/kernel/cmdline")
 	current, _ := ioutil.ReadFile(path)
@@ -98,7 +98,7 @@ func (fd *FilesystemDeployAction) setupKernelCmdline(context *debos.DebosContext
 	defer f.Close()
 
 	if err != nil {
-		return fmt.Errorf("Couldn't open /etc/kernel/cmdline: %v", err)
+		return fmt.Errorf("couldn't open /etc/kernel/cmdline: %v", err)
 	}
 
 	cmdline = append(cmdline, strings.TrimSpace(string(current)))
@@ -110,7 +110,7 @@ func (fd *FilesystemDeployAction) setupKernelCmdline(context *debos.DebosContext
 
 	_, err = f.WriteString(strings.Join(cmdline, " ") + "\n")
 	if err != nil {
-		return fmt.Errorf("Couldn't write /etc/kernel/cmdline: %v", err)
+		return fmt.Errorf("couldn't write /etc/kernel/cmdline: %v", err)
 	}
 
 	return nil

--- a/actions/image_partition_action.go
+++ b/actions/image_partition_action.go
@@ -274,7 +274,7 @@ func (i *ImagePartitionAction) generateFSTab(context *debos.DebosContext) error 
 	for _, m := range i.Mountpoints {
 		options := []string{"defaults"}
 		options = append(options, m.Options...)
-		if m.Buildtime == true {
+		if m.Buildtime {
 			/* Do not need to add mount point into fstab */
 			continue
 		}
@@ -714,7 +714,7 @@ func (i ImagePartitionAction) Cleanup(context *debos.DebosContext) error {
 			log.Printf("Unmount failure can cause images being incomplete!")
 			return err
 		}
-		if m.Buildtime == true {
+		if m.Buildtime {
 			if err = os.Remove(mntpath); err != nil {
 				log.Printf("Failed to remove temporary mount point %s: %s", m.Mountpoint, err)
 

--- a/actions/image_partition_action.go
+++ b/actions/image_partition_action.go
@@ -597,7 +597,7 @@ func (i ImagePartitionAction) Run(context *debos.DebosContext) error {
 			}
 		}
 
-		if p.PartAttrs != nil && len(p.PartAttrs) > 0 {
+		if len(p.PartAttrs) > 0 {
 			/* Convert bits numbers to bits names due to a libfdisk's limitation
 			 * https://github.com/util-linux/util-linux/issues/3353
 			 */
@@ -673,15 +673,8 @@ func (i ImagePartitionAction) Run(context *debos.DebosContext) error {
 		os.MkdirAll(mntpath, 0755)
 		fsType := m.part.FS
 		switch m.part.FS {
-<<<<<<< HEAD
 		case "fat", "fat12", "fat16", "fat32", "msdos":
 			fsType = "vfat"
-		default:
-			break
-=======
-			case "fat", "fat12", "fat16", "fat32", "msdos":
-				fsType = "vfat"
->>>>>>> c233650 (fix: Break statement with no effect (SA4011))
 		}
 		err = syscall.Mount(dev, mntpath, fsType, 0, "")
 		if err != nil {

--- a/actions/image_partition_action.go
+++ b/actions/image_partition_action.go
@@ -296,8 +296,6 @@ func (i *ImagePartitionAction) generateFSTab(context *debos.DebosContext) error 
 		switch m.part.FS {
 		case "fat", "fat12", "fat16", "fat32", "msdos":
 			fsType = "vfat"
-		default:
-			break
 		}
 
 		context.ImageFSTab.WriteString(fmt.Sprintf("UUID=%s\t%s\t%s\t%s\t0\t%d\n",
@@ -675,10 +673,15 @@ func (i ImagePartitionAction) Run(context *debos.DebosContext) error {
 		os.MkdirAll(mntpath, 0755)
 		fsType := m.part.FS
 		switch m.part.FS {
+<<<<<<< HEAD
 		case "fat", "fat12", "fat16", "fat32", "msdos":
 			fsType = "vfat"
 		default:
 			break
+=======
+			case "fat", "fat12", "fat16", "fat32", "msdos":
+				fsType = "vfat"
+>>>>>>> c233650 (fix: Break statement with no effect (SA4011))
 		}
 		err = syscall.Mount(dev, mntpath, fsType, 0, "")
 		if err != nil {

--- a/actions/image_partition_action.go
+++ b/actions/image_partition_action.go
@@ -279,7 +279,7 @@ func (i *ImagePartitionAction) generateFSTab(context *debos.DebosContext) error 
 			continue
 		}
 		if m.part.FSUUID == "" {
-			return fmt.Errorf("Missing fs UUID for partition %s!?!", m.part.Name)
+			return fmt.Errorf("missing fs UUID for partition %s", m.part.Name)
 		}
 
 		fs_passno := 0
@@ -312,7 +312,7 @@ func (i *ImagePartitionAction) generateKernelRoot(context *debos.DebosContext) e
 	for _, m := range i.Mountpoints {
 		if m.Mountpoint == "/" {
 			if m.part.FSUUID == "" {
-				return errors.New("No fs UUID for root partition !?!")
+				return errors.New("no fs UUID for root partition")
 			}
 			context.ImageKernelRoot = fmt.Sprintf("root=UUID=%s", m.part.FSUUID)
 			break
@@ -458,7 +458,7 @@ func (i ImagePartitionAction) formatPartition(p *Partition, context debos.DebosC
 	if p.FS != "none" && p.FSUUID == "" {
 		uuid, err := exec.Command("blkid", "-o", "value", "-s", "UUID", "-p", "-c", "none", path).Output()
 		if err != nil {
-			return fmt.Errorf("Failed to get uuid: %s", err)
+			return fmt.Errorf("failed to get uuid: %s", err)
 		}
 		p.FSUUID = strings.TrimSpace(string(uuid[:]))
 	}
@@ -470,12 +470,12 @@ func (i *ImagePartitionAction) PreNoMachine(context *debos.DebosContext) error {
 	imagePath := path.Join(context.Artifactdir, i.ImageName)
 	img, err := os.OpenFile(imagePath, os.O_WRONLY|os.O_CREATE, 0666)
 	if err != nil {
-		return fmt.Errorf("Couldn't open image file: %v", err)
+		return fmt.Errorf("couldn't open image file: %v", err)
 	}
 
 	err = img.Truncate(i.size)
 	if err != nil {
-		return fmt.Errorf("Couldn't resize image file: %v", err)
+		return fmt.Errorf("couldn't resize image file: %v", err)
 	}
 
 	img.Close()
@@ -492,7 +492,7 @@ func (i *ImagePartitionAction) PreNoMachine(context *debos.DebosContext) error {
 	}
 
 	if err != nil {
-		return fmt.Errorf("Failed to setup loop device: %v", err)
+		return fmt.Errorf("failed to setup loop device: %v", err)
 	}
 
 	// go-losetup doesn't provide a way to change the loop device sector size
@@ -804,7 +804,7 @@ func (i *ImagePartitionAction) Verify(context *debos.DebosContext) error {
 		// Just check if it contains correct value
 		_, err := units.FromHumanSize(i.GptGap)
 		if err != nil {
-			return fmt.Errorf("Failed to parse GPT offset: %s", i.GptGap)
+			return fmt.Errorf("failed to parse image size: %s", i.GptGap)
 		}
 	}
 
@@ -813,12 +813,12 @@ func (i *ImagePartitionAction) Verify(context *debos.DebosContext) error {
 		case "gpt":
 			_, err := uuid.Parse(i.DiskID)
 			if err != nil {
-				return fmt.Errorf("Incorrect disk GUID %s", i.DiskID)
+				return fmt.Errorf("incorrect disk GUID %s", i.DiskID)
 			}
 		case "msdos":
 			_, err := hex.DecodeString(i.DiskID)
 			if err != nil || len(i.DiskID) != 8 {
-				return fmt.Errorf("Incorrect disk ID %s, should be 32-bit hexadecimal number", i.DiskID)
+				return fmt.Errorf("incorrect disk ID %s, should be 32-bit hexadecimal number", i.DiskID)
 			}
 			// Add 0x prefix
 			i.DiskID = "0x" + i.DiskID
@@ -832,13 +832,13 @@ func (i *ImagePartitionAction) Verify(context *debos.DebosContext) error {
 		p.number = num
 		num++
 		if p.Name == "" {
-			return fmt.Errorf("Partition without a name")
+			return fmt.Errorf("partition without a name")
 		}
 
 		// check for duplicate partition names
 		for j := idx + 1; j < len(i.Partitions); j++ {
 			if i.Partitions[j].Name == p.Name {
-				return fmt.Errorf("Partition %s already exists", p.Name)
+				return fmt.Errorf("partition %s already exists", p.Name)
 			}
 		}
 
@@ -847,20 +847,20 @@ func (i *ImagePartitionAction) Verify(context *debos.DebosContext) error {
 			case "btrfs", "ext2", "ext3", "ext4", "xfs":
 				_, err := uuid.Parse(p.FSUUID)
 				if err != nil {
-					return fmt.Errorf("Incorrect UUID %s", p.FSUUID)
+					return fmt.Errorf("incorrect UUID %s", p.FSUUID)
 				}
 			case "fat", "fat12", "fat16", "fat32", "msdos", "vfat":
 				_, err := hex.DecodeString(p.FSUUID)
 				if err != nil || len(p.FSUUID) != 8 {
-					return fmt.Errorf("Incorrect UUID %s, should be 32-bit hexadecimal number", p.FSUUID)
+					return fmt.Errorf("incorrect UUID %s, should be 32-bit hexadecimal number", p.FSUUID)
 				}
 			default:
-				return fmt.Errorf("Setting the UUID is not supported for filesystem %s", p.FS)
+				return fmt.Errorf("setting the UUID is not supported for filesystem %s", p.FS)
 			}
 		}
 
 		if i.PartitionType != "gpt" && p.PartLabel != "" {
-			return fmt.Errorf("Can only set partition partlabel on GPT filesystem")
+			return fmt.Errorf("can only set partition partlabel on GPT filesystem")
 		}
 
 		if len(p.PartUUID) > 0 {
@@ -868,10 +868,10 @@ func (i *ImagePartitionAction) Verify(context *debos.DebosContext) error {
 			case "gpt":
 				_, err := uuid.Parse(p.PartUUID)
 				if err != nil {
-					return fmt.Errorf("Incorrect partition UUID %s", p.PartUUID)
+					return fmt.Errorf("incorrect partition UUID %s", p.PartUUID)
 				}
 			default:
-				return fmt.Errorf("Setting the partition UUID is not supported for %s", i.PartitionType)
+				return fmt.Errorf("setting the partition UUID is not supported for %s", i.PartitionType)
 			}
 		}
 
@@ -891,19 +891,19 @@ func (i *ImagePartitionAction) Verify(context *debos.DebosContext) error {
 		for _, bitStr := range p.PartAttrs {
 			bit, err := strconv.ParseInt(bitStr, 0, 0)
 			if err != nil || bit < 0 || bit > 2 && bit < 48 || bit > 63 {
-				return fmt.Errorf("Partition attribute bit '%s' outside of valid range (0-2, 48-63)", bitStr)
+				return fmt.Errorf("partition attribute bit '%s' outside of valid range (0-2, 48-63)", bitStr)
 			}
 		}
 
 		if p.Start == "" {
-			return fmt.Errorf("Partition %s missing start", p.Name)
+			return fmt.Errorf("partition %s missing start", p.Name)
 		}
 		if p.End == "" {
-			return fmt.Errorf("Partition %s missing end", p.Name)
+			return fmt.Errorf("partition %s missing end", p.Name)
 		}
 
 		if p.FS == "" {
-			return fmt.Errorf("Partition %s missing fs type", p.Name)
+			return fmt.Errorf("partition %s missing fs type", p.Name)
 		}
 
 		if p.FSLabel == "" {
@@ -939,7 +939,7 @@ func (i *ImagePartitionAction) Verify(context *debos.DebosContext) error {
 		// check for duplicate mountpoints
 		for j := idx + 1; j < len(i.Mountpoints); j++ {
 			if i.Mountpoints[j].Mountpoint == m.Mountpoint {
-				return fmt.Errorf("Mountpoint %s already exists", m.Mountpoint)
+				return fmt.Errorf("mountpoint %s already exists", m.Mountpoint)
 			}
 		}
 
@@ -951,11 +951,11 @@ func (i *ImagePartitionAction) Verify(context *debos.DebosContext) error {
 			}
 		}
 		if m.part == nil {
-			return fmt.Errorf("Couldn't find partition for %s", m.Mountpoint)
+			return fmt.Errorf("couldn't find partition for %s", m.Mountpoint)
 		}
 
 		if strings.ToLower(m.part.FS) == "none" {
-			return fmt.Errorf("Cannot mount %s: filesystem not present", m.Mountpoint)
+			return fmt.Errorf("cannot mount %s: filesystem not present", m.Mountpoint)
 		}
 	}
 
@@ -971,7 +971,7 @@ func (i *ImagePartitionAction) Verify(context *debos.DebosContext) error {
 
 	size, err := getSizeValueFunc(i.ImageSize)
 	if err != nil {
-		return fmt.Errorf("Failed to parse image size: %s", i.ImageSize)
+		return fmt.Errorf("failed to parse image size: %s", i.ImageSize)
 	}
 
 	i.size = size

--- a/actions/image_partition_action.go
+++ b/actions/image_partition_action.go
@@ -823,7 +823,7 @@ func (i *ImagePartitionAction) Verify(context *debos.DebosContext) error {
 
 	num := 1
 	for idx := range i.Partitions {
-		var maxLength int = 0
+		var maxLength = 0
 		p := &i.Partitions[idx]
 		p.number = num
 		num++

--- a/actions/ostree_deploy_action.go
+++ b/actions/ostree_deploy_action.go
@@ -93,10 +93,10 @@ func (ot *OstreeDeployAction) setupFSTab(deployment *ostree.Deployment, context 
 	}
 
 	dst, err := os.OpenFile(path.Join(etcDir, "fstab"), os.O_WRONLY|os.O_CREATE, 0755)
-	defer dst.Close()
 	if err != nil {
 		return err
 	}
+	defer dst.Close()
 
 	_, err = io.Copy(dst, &context.ImageFSTab)
 

--- a/actions/overlay_action.go
+++ b/actions/overlay_action.go
@@ -53,7 +53,7 @@ func (overlay *OverlayAction) Run(context *debos.DebosContext) error {
 	if len(overlay.Origin) > 0 {
 		var found bool
 		if origin, found = context.Origin(overlay.Origin); !found {
-			return fmt.Errorf("Origin not found '%s'", overlay.Origin)
+			return fmt.Errorf("origin not found '%s'", overlay.Origin)
 		}
 	}
 

--- a/actions/pack_action.go
+++ b/actions/pack_action.go
@@ -67,7 +67,7 @@ func (pf *PackAction) Verify(context *debos.DebosContext) error {
 		possibleTypes = append(possibleTypes, key)
 	}
 
-	return fmt.Errorf("Option 'compression' has an unsupported type: `%s`. Possible types are %s.",
+	return fmt.Errorf("option 'compression' has an unsupported type: `%s`; possible types are %s",
 		pf.Compression, strings.Join(possibleTypes, ", "))
 }
 

--- a/actions/pack_action.go
+++ b/actions/pack_action.go
@@ -85,7 +85,7 @@ func (pf *PackAction) Run(context *debos.DebosContext) error {
 	command = append(command, outfile)
 	command = append(command, "--xattrs")
 	command = append(command, "--xattrs-include=*.*")
-	if usePigz == true {
+	if usePigz {
 		command = append(command, "--use-compress-program=pigz")
 	} else if tarOpts[pf.Compression] != "" {
 		command = append(command, tarOpts[pf.Compression])

--- a/actions/pacstrap_action.go
+++ b/actions/pacstrap_action.go
@@ -35,13 +35,13 @@ func (d *PacstrapAction) listOptionFiles(context *debos.DebosContext) ([]string,
 	files := []string{}
 
 	if d.Config == "" {
-		return nil, fmt.Errorf("No config file set")
+		return nil, fmt.Errorf("no config file set")
 	}
 	d.Config = debos.CleanPathAt(d.Config, context.RecipeDir)
 	files = append(files, d.Config)
 
 	if d.Mirror == "" {
-		return nil, fmt.Errorf("No mirror file set")
+		return nil, fmt.Errorf("no mirror file set")
 	}
 	d.Mirror = debos.CleanPathAt(d.Mirror, context.RecipeDir)
 	files = append(files, d.Mirror)
@@ -110,13 +110,13 @@ func (d *PacstrapAction) Run(context *debos.DebosContext) error {
 	// Even if we did, blindly copying it might not be a good idea.
 	cmdline := []string{"pacman-key", "--init"}
 	if err := (debos.Command{}.Run("pacman-key", cmdline...)); err != nil {
-		return fmt.Errorf("Couldn't init pacman keyring: %v", err)
+		return fmt.Errorf("couldn't init pacman keyring: %v", err)
 	}
 
 	// When there's no explicit keyring suite we populate all available
 	cmdline = []string{"pacman-key", "--populate"}
 	if err := (debos.Command{}.Run("pacman-key", cmdline...)); err != nil {
-		return fmt.Errorf("Couldn't populate pacman keyring: %v", err)
+		return fmt.Errorf("couldn't populate pacman keyring: %v", err)
 	}
 
 	// Run pacstrap

--- a/actions/pacstrap_action.go
+++ b/actions/pacstrap_action.go
@@ -17,7 +17,7 @@ package actions
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io/fs"
 	"os"
 	"path"
 
@@ -95,12 +95,12 @@ func (d *PacstrapAction) Run(context *debos.DebosContext) error {
 			return err
 		}
 
-		read, err := ioutil.ReadFile(src)
+		read, err := os.ReadFile(src)
 		if err != nil {
 			return err
 		}
 
-		if err = ioutil.WriteFile(dest, read, 0644); err != nil {
+		if err = os.WriteFile(dest, read, fs.FileMode(0644)); err != nil {
 			return err
 		}
 	}

--- a/actions/raw_action.go
+++ b/actions/raw_action.go
@@ -32,7 +32,6 @@ package actions
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"path"
@@ -92,7 +91,7 @@ func (raw *RawAction) Run(context *debos.DebosContext) error {
 		return fmt.Errorf("origin `%s` doesn't exist", raw.Origin)
 	}
 	s := path.Join(origin, raw.Source)
-	content, err := ioutil.ReadFile(s)
+	content, err := os.ReadFile(s)
 
 	if err != nil {
 		return fmt.Errorf("failed to read %s", s)

--- a/actions/raw_action.go
+++ b/actions/raw_action.go
@@ -61,7 +61,7 @@ func (raw *RawAction) checkDeprecatedSyntax() error {
 		log.Printf("Usage of 'source' and 'path' properties is deprecated.")
 		log.Printf("Please use 'origin' and 'source' properties.")
 		if len(raw.Origin) > 0 {
-			return errors.New("Can't mix 'origin' and 'path'(deprecated option) properties")
+			return errors.New("can't mix 'origin' and 'path'(deprecated option) properties")
 		}
 		if len(raw.Source) == 0 {
 			return errors.New("'source' and 'path' properties can't be empty")
@@ -89,13 +89,13 @@ func (raw *RawAction) Verify(context *debos.DebosContext) error {
 func (raw *RawAction) Run(context *debos.DebosContext) error {
 	origin, found := context.Origin(raw.Origin)
 	if !found {
-		return fmt.Errorf("Origin `%s` doesn't exist\n", raw.Origin)
+		return fmt.Errorf("origin `%s` doesn't exist", raw.Origin)
 	}
 	s := path.Join(origin, raw.Source)
 	content, err := ioutil.ReadFile(s)
 
 	if err != nil {
-		return fmt.Errorf("Failed to read %s", s)
+		return fmt.Errorf("failed to read %s", s)
 	}
 
 	var devicePath string
@@ -108,7 +108,7 @@ func (raw *RawAction) Run(context *debos.DebosContext) error {
 		}
 
 		if devicePath == "" {
-			return fmt.Errorf("Failed to find partition named %s", raw.Partition)
+			return fmt.Errorf("failed to find partition named %s", raw.Partition)
 		}
 	} else {
 		devicePath = context.Image
@@ -116,7 +116,7 @@ func (raw *RawAction) Run(context *debos.DebosContext) error {
 
 	target, err := os.OpenFile(devicePath, os.O_WRONLY, 0)
 	if err != nil {
-		return fmt.Errorf("Failed to open %s: %v", devicePath, err)
+		return fmt.Errorf("failed to open %s: %v", devicePath, err)
 	}
 	defer target.Close()
 
@@ -130,7 +130,7 @@ func (raw *RawAction) Run(context *debos.DebosContext) error {
 		}
 		offset, err = strconv.ParseInt(offs, 0, 64)
 		if err != nil {
-			return fmt.Errorf("Couldn't parse offset %v", err)
+			return fmt.Errorf("couldn't parse offset %v", err)
 		}
 
 		if sector {
@@ -140,12 +140,12 @@ func (raw *RawAction) Run(context *debos.DebosContext) error {
 
 	bytes, err := target.WriteAt(content, offset)
 	if bytes != len(content) {
-		return fmt.Errorf("Couldn't write complete data %v", err)
+		return fmt.Errorf("couldn't write complete data %v", err)
 	}
 
 	err = target.Sync()
 	if err != nil {
-		return fmt.Errorf("Couldn't sync content %v", err)
+		return fmt.Errorf("couldn't sync content %v", err)
 	}
 
 	return nil

--- a/actions/recipe.go
+++ b/actions/recipe.go
@@ -155,7 +155,7 @@ func (y *YamlAction) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	case "recipe":
 		y.Action = &RecipeAction{}
 	default:
-		return fmt.Errorf("Unknown action: %v", aux.Action)
+		return fmt.Errorf("unknown action: %v", aux.Action)
 	}
 
 	err = unmarshal(y.Action)

--- a/actions/recipe_action.go
+++ b/actions/recipe_action.go
@@ -77,7 +77,7 @@ func (recipe *RecipeAction) Verify(context *debos.DebosContext) error {
 	}
 
 	if recipe.context.Architecture != recipe.Actions.Architecture {
-		return fmt.Errorf("Expect architecture '%s' but got '%s'", context.Architecture, recipe.Actions.Architecture)
+		return fmt.Errorf("expected architecture '%s' but got '%s'", context.Architecture, recipe.Actions.Architecture)
 	}
 
 	for _, a := range recipe.Actions.Actions {

--- a/actions/recipe_test.go
+++ b/actions/recipe_test.go
@@ -72,7 +72,7 @@ architecture: arm64
 actions:
   - action: test_unknown_action
 `,
-			"Unknown action: test_unknown_action",
+			"unknown action: test_unknown_action",
 		},
 		// Test if 'architecture' property absence
 		{`
@@ -147,7 +147,7 @@ architecture: arm64
 actions:
   - action: {{ sector 42 }}
 `,
-		"Unknown action: 42s",
+		"unknown action: 42s",
 	}
 	runTest(t, testSector)
 }
@@ -281,7 +281,7 @@ actions:
     recipe: armhf.yaml
 `,
 			recipeArmhf,
-			"Expect architecture 'amd64' but got 'armhf'",
+			"expected architecture 'amd64' but got 'armhf'",
 			"", // Do not expect parse failure
 		},
 		{

--- a/actions/recipe_test.go
+++ b/actions/recipe_test.go
@@ -4,7 +4,6 @@ import (
 	"github.com/go-debos/debos"
 	"github.com/go-debos/debos/actions"
 	"github.com/stretchr/testify/assert"
-	"io/ioutil"
 	"os"
 	"strings"
 	"testing"
@@ -153,7 +152,7 @@ actions:
 }
 
 func runTest(t *testing.T, test testRecipe, templateVars ...map[string]string) actions.Recipe {
-	file, err := ioutil.TempFile(os.TempDir(), "recipe")
+	file, err := os.CreateTemp(os.TempDir(), "recipe")
 	assert.Empty(t, err)
 	defer os.Remove(file.Name())
 
@@ -308,11 +307,11 @@ actions:
 
 func runTestWithSubRecipes(t *testing.T, test testSubRecipe, templateVars ...map[string]string) actions.Recipe {
 	context := debos.DebosContext{&debos.CommonContext{}, "", "", 512}
-	dir, err := ioutil.TempDir("", "go-debos")
+	dir, err := os.MkdirTemp("", "go-debos")
 	assert.Empty(t, err)
 	defer os.RemoveAll(dir)
 
-	file, err := ioutil.TempFile(dir, "recipe")
+	file, err := os.CreateTemp(dir, "recipe")
 	assert.Empty(t, err)
 	defer os.Remove(file.Name())
 

--- a/actions/run_action.go
+++ b/actions/run_action.go
@@ -65,11 +65,11 @@ type RunAction struct {
 
 func (run *RunAction) Verify(context *debos.DebosContext) error {
 	if run.PostProcess && run.Chroot {
-		return errors.New("Cannot run postprocessing in the chroot")
+		return errors.New("cannot run postprocessing in the chroot")
 	}
 
 	if run.Script == "" && run.Command == "" {
-		return errors.New("Script and Command both cannot be empty")
+		return errors.New("need to set 'script' or 'command'")
 	}
 	return nil
 }

--- a/actions/unpack_action.go
+++ b/actions/unpack_action.go
@@ -47,7 +47,7 @@ type UnpackAction struct {
 func (pf *UnpackAction) Verify(context *debos.DebosContext) error {
 
 	if len(pf.Origin) == 0 && len(pf.File) == 0 {
-		return fmt.Errorf("Filename can't be empty. Please add 'file' and/or 'origin' property.")
+		return fmt.Errorf("filename can't be empty. Please add 'file' and/or 'origin' property")
 	}
 
 	archive, err := debos.NewArchive(pf.File)
@@ -56,7 +56,7 @@ func (pf *UnpackAction) Verify(context *debos.DebosContext) error {
 	}
 	if len(pf.Compression) > 0 {
 		if archive.Type() != debos.Tar {
-			return fmt.Errorf("Option 'compression' is supported for Tar archives only.")
+			return fmt.Errorf("option 'compression' is supported for Tar archives only")
 		}
 		if err := archive.AddOption("tarcompression", pf.Compression); err != nil {
 			return fmt.Errorf("'%s': %s", pf.File, err)
@@ -74,7 +74,7 @@ func (pf *UnpackAction) Run(context *debos.DebosContext) error {
 		//Trying to get a filename from origins first
 		origin, found = context.Origin(pf.Origin)
 		if !found {
-			return fmt.Errorf("Origin not found '%s'", pf.Origin)
+			return fmt.Errorf("origin not found '%s'", pf.Origin)
 		}
 	} else {
 		origin = context.Artifactdir

--- a/archiver.go
+++ b/archiver.go
@@ -104,9 +104,7 @@ func (tar *ArchiveTar) Unpack(destination string) error {
 		}
 	}
 	if options, ok := tar.options["taroptions"].([]string); ok {
-		for _, option := range options {
-			command = append(command, option)
-		}
+		command = append(command, options...)
 	}
 	command = append(command, "-C", destination)
 	command = append(command, "-x")
@@ -134,9 +132,7 @@ func (tar *ArchiveTar) RelaxedUnpack(destination string) error {
 	defer func() { tar.options["taroptions"] = options }()
 
 	if ok {
-		for _, option := range options {
-			taroptions = append(taroptions, option)
-		}
+		taroptions = append(taroptions, options...)
 	}
 	tar.options["taroptions"] = taroptions
 

--- a/archiver.go
+++ b/archiver.go
@@ -150,23 +150,23 @@ func (tar *ArchiveTar) AddOption(key, value interface{}) error {
 		// expect a slice
 		options, ok := value.([]string)
 		if !ok {
-			return fmt.Errorf("Wrong type for value")
+			return fmt.Errorf("wrong type for value")
 		}
 		tar.options["taroptions"] = options
 
 	case "tarcompression":
 		compression, ok := value.(string)
 		if !ok {
-			return fmt.Errorf("Wrong type for value")
+			return fmt.Errorf("wrong type for value")
 		}
 		option := tarOptions(compression)
 		if len(option) == 0 {
-			return fmt.Errorf("Compression '%s' is not supported", compression)
+			return fmt.Errorf("compression '%s' is not supported", compression)
 		}
 		tar.options["tarcompression"] = compression
 
 	default:
-		return fmt.Errorf("Option '%v' is not supported for tar archive type", key)
+		return fmt.Errorf("option '%v' is not supported for tar archive type", key)
 	}
 	return nil
 }
@@ -228,7 +228,7 @@ func NewArchive(file string, arcType ...ArchiveType) (Archive, error) {
 	case Deb:
 		archive = Archive{&ArchiveDeb{ArchiveBase: common}}
 	default:
-		return archive, fmt.Errorf("Unsupported archive '%s'", file)
+		return archive, fmt.Errorf("unsupported archive '%s'", file)
 	}
 	return archive, nil
 }

--- a/archiver.go
+++ b/archiver.go
@@ -115,7 +115,7 @@ func (tar *ArchiveTar) Unpack(destination string) error {
 
 	if compression, ok := tar.options["tarcompression"]; ok {
 		if unpackTarOpt := tarOptions(compression.(string)); len(unpackTarOpt) > 0 {
-			if usePigz == true {
+			if usePigz {
 				command = append(command, "--use-compress-program=pigz")
 			} else {
 				command = append(command, unpackTarOpt)

--- a/archiver_test.go
+++ b/archiver_test.go
@@ -14,7 +14,7 @@ func TestBase(t *testing.T) {
 	// New archive
 	// Expect Tar by default
 	_, err := debos.NewArchive("test.base", 0)
-	assert.EqualError(t, err, "Unsupported archive 'test.base'")
+	assert.EqualError(t, err, "unsupported archive 'test.base'")
 
 	// Test base
 	archive := debos.ArchiveBase{}
@@ -64,7 +64,7 @@ func TestTar_default(t *testing.T) {
 
 	// Add wrong option
 	err = archive.AddOption("someoption", "somevalue")
-	assert.EqualError(t, err, "Option 'someoption' is not supported for tar archive type")
+	assert.EqualError(t, err, "option 'someoption' is not supported for tar archive type")
 }
 
 // Check supported compression types
@@ -91,13 +91,13 @@ func TestTar_compression(t *testing.T) {
 	}
 	// Check of unsupported compression type
 	err = archive.AddOption("tarcompression", "fake")
-	assert.EqualError(t, err, "Compression 'fake' is not supported")
+	assert.EqualError(t, err, "compression 'fake' is not supported")
 
 	// Pass incorrect type
 	err = archive.AddOption("taroptions", nil)
-	assert.EqualError(t, err, "Wrong type for value")
+	assert.EqualError(t, err, "wrong type for value")
 	err = archive.AddOption("tarcompression", nil)
-	assert.EqualError(t, err, "Wrong type for value")
+	assert.EqualError(t, err, "wrong type for value")
 }
 
 func TestDeb(t *testing.T) {

--- a/cmd/debos/debos.go
+++ b/cmd/debos/debos.go
@@ -363,7 +363,7 @@ func main() {
 
 		if options.DebugShell {
 			args = append(args, "--debug-shell")
-			args = append(args, "--shell", fmt.Sprintf("%s", options.Shell))
+			args = append(args, "--shell", options.Shell)
 		}
 
 		for _, a := range r.Actions {

--- a/cmd/debos/debos.go
+++ b/cmd/debos/debos.go
@@ -223,7 +223,7 @@ func main() {
 	if !runInFakeMachine && !fakemachine.InMachine() {
 		log.Printf("fakemachine not supported, running on the host!")
 		cwd, _ := os.Getwd()
-		context.Scratchdir, err = os.MkdirTemp(cwd, ".debos-")
+		context.Scratchdir, _ = os.MkdirTemp(cwd, ".debos-")
 		defer os.RemoveAll(context.Scratchdir)
 	}
 

--- a/cmd/debos/debos.go
+++ b/cmd/debos/debos.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"path"
@@ -224,7 +223,7 @@ func main() {
 	if !runInFakeMachine && !fakemachine.InMachine() {
 		log.Printf("fakemachine not supported, running on the host!")
 		cwd, _ := os.Getwd()
-		context.Scratchdir, err = ioutil.TempDir(cwd, ".debos-")
+		context.Scratchdir, err = os.MkdirTemp(cwd, ".debos-")
 		defer os.RemoveAll(context.Scratchdir)
 	}
 

--- a/commands.go
+++ b/commands.go
@@ -332,7 +332,7 @@ func newQemuHelper(c Command) (*qemuHelper, error) {
 			q.qemusrc = "/usr/bin/qemu-sh4-static"
 		}
 	default:
-		return nil, fmt.Errorf("Don't know qemu for architecture %s", c.Architecture)
+		return nil, fmt.Errorf("unsupported qemu architecture %s", c.Architecture)
 	}
 
 	if q.qemusrc != "" {

--- a/commands.go
+++ b/commands.go
@@ -5,7 +5,6 @@ import (
 	"crypto/sha256"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 	"os/exec"
@@ -136,7 +135,7 @@ func (cmd *Command) saveResolvConf() (*[sha256.Size]byte, error) {
 	}
 
 	/* Expect a relatively small file here */
-	data, err := ioutil.ReadFile(hostconf)
+	data, err := os.ReadFile(hostconf)
 	if err != nil {
 		return nil, err
 	}
@@ -145,7 +144,7 @@ func (cmd *Command) saveResolvConf() (*[sha256.Size]byte, error) {
 
 	sum = sha256.Sum256(out)
 
-	err = ioutil.WriteFile(chrootedconf, out, 0644)
+	err = os.WriteFile(chrootedconf, out, 0644)
 	if err != nil {
 		return nil, err
 	}
@@ -177,7 +176,7 @@ func (cmd *Command) restoreResolvConf(sum *[sha256.Size]byte) error {
 	switch {
 	case mode.IsRegular():
 		// Try to calculate checksum
-		data, err := ioutil.ReadFile(chrootedconf)
+		data, err := os.ReadFile(chrootedconf)
 		if err != nil {
 			return err
 		}

--- a/commands.go
+++ b/commands.go
@@ -183,7 +183,7 @@ func (cmd *Command) restoreResolvConf(sum *[sha256.Size]byte) error {
 		currentsum := sha256.Sum256(data)
 
 		// Leave the changed resolv.conf untouched
-		if bytes.Compare(currentsum[:], (*sum)[:]) == 0 {
+		if bytes.Equal(currentsum[:], (*sum)[:]) {
 			// Remove the generated version
 			if err := os.Remove(chrootedconf); err != nil {
 				return err

--- a/filesystem.go
+++ b/filesystem.go
@@ -69,18 +69,18 @@ func CopyTree(sourcetree, desttree string) error {
 		case 0:
 			err := CopyFile(p, target, info.Mode())
 			if err != nil {
-				return fmt.Errorf("Failed to copy file %s: %w", p, err)
+				return fmt.Errorf("failed to copy file %s: %w", p, err)
 			}
 		case os.ModeDir:
 			os.Mkdir(target, info.Mode())
 		case os.ModeSymlink:
 			link, err := os.Readlink(p)
 			if err != nil {
-				return fmt.Errorf("Failed to read symlink %s: %w", suffix, err)
+				return fmt.Errorf("failed to read symlink %s: %w", suffix, err)
 			}
 			os.Symlink(link, target)
 		default:
-			return fmt.Errorf("File %s with mode %v not handled", p, info.Mode())
+			return fmt.Errorf("file %s with mode %v not handled", p, info.Mode())
 		}
 
 		return nil
@@ -106,7 +106,7 @@ func RestrictedPath(prefix, dest string) (string, error) {
 		return "", err
 	}
 	if !strings.HasPrefix(destination, prefix) {
-		return "", fmt.Errorf("The resulting path points outside of prefix '%s': '%s'\n", prefix, destination)
+		return "", fmt.Errorf("resulting path points outside of prefix '%s': '%s'", prefix, destination)
 	}
 	return destination, nil
 }

--- a/filesystem.go
+++ b/filesystem.go
@@ -3,7 +3,6 @@ package debos
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -29,7 +28,7 @@ func CopyFile(src, dst string, mode os.FileMode) error {
 		return err
 	}
 	defer in.Close()
-	tmp, err := ioutil.TempFile(filepath.Dir(dst), "")
+	tmp, err := os.CreateTemp(filepath.Dir(dst), "")
 	if err != nil {
 		return err
 	}

--- a/net.go
+++ b/net.go
@@ -17,7 +17,7 @@ func DownloadHttpUrl(url, filename string) error {
 	// Check if file object already exists.
 	fi, err := os.Stat(filename)
 	if !os.IsNotExist(err) && !fi.Mode().IsRegular() {
-		return fmt.Errorf("Failed to download '%s': '%s' exists and it is not a regular file\n", url, filename)
+		return fmt.Errorf("failed to download '%s': '%s' exists and it is not a regular file", url, filename)
 	}
 
 	resp, err := http.Get(url)
@@ -27,7 +27,7 @@ func DownloadHttpUrl(url, filename string) error {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("Url '%s' returned status code %d (%s)\n", url, resp.StatusCode, http.StatusText(resp.StatusCode))
+		return fmt.Errorf("url '%s' returned status code %d (%s)", url, resp.StatusCode, http.StatusText(resp.StatusCode))
 	}
 
 	// Output file

--- a/os.go
+++ b/os.go
@@ -50,7 +50,7 @@ exit 101
 `)
 
 	if _, err := os.Stat(helperFile); os.IsExist(err) {
-		return fmt.Errorf("Policy helper file '%s' exists already", debianPolicyHelper)
+		return fmt.Errorf("policy helper file '%s' exists already", debianPolicyHelper)
 	}
 	if _, err := os.Stat(path.Dir(helperFile)); os.IsNotExist(err) {
 		// do not try to do something if ".../usr/sbin" is not exists


### PR DESCRIPTION
Add support for staticcheck: fix all issues reported by staticcheck and run it
as part of CI.

Note the ioutil changes break backward compatibility with very old golang by
addressing deprecations from 1.19, but the oldest supported Debian release
seems to be bookworm, and it has a newer golang than that.

Did a couple of gitignore tweaks along the way.

Commits:
- **fix: Incorrectly formatted error string (ST1005)**
- **fix: Unnecessary use of fmt.Sprintf (S1039)**
- **fix: Omit comparison with boolean constant (S1002)**
- **fix: Using a deprecated function, variable, constant or field (SA1019)**
- **fix: Deferring Close before checking for a possible error (SA5001)**
- **fix: Use a single append to concatenate two slices (S1011)**
- **fix: Break statement with no effect (SA4011)**
- **fix: Replace call to bytes.Compare with bytes.Equal (S1004)**
- **fix: Omit redundant nil check on slices, maps, and channels (S1009)**
- **fix: Don’t use fmt.Sprintf("%s", x) unnecessarily (S1025)**
- **fix: A value assigned to a variable is never read before being overwritten (SA4006)**
- **fix: Omit redundant type from variable declaration (QF1011)**
- **ci: Enable staticcheck linter in golangci.yml**
- **docs: Add debos to gitignore**
- **docs: Refresh generated gitignore section**
- **docs: Add visualstudiocode to generated gitignore**
