### PR TITLE
govet

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,6 +2,7 @@ version: "2"
 linters:
   default: none
   enable:
+    - govet
     - staticcheck
 formatters:
   enable:

--- a/actions/image_partition_action.go
+++ b/actions/image_partition_action.go
@@ -215,7 +215,7 @@ type Partition struct {
 	Flags           []string
 	Features        []string
 	ExtendedOptions []string
-	Fsck            bool "fsck"
+	Fsck            bool   `yaml:"fsck"`
 	FSUUID          string
 }
 
@@ -250,7 +250,7 @@ type ImagePartitionAction struct {
 	ImageSize        string
 	PartitionType    string
 	DiskID           string
-	GptGap           string "gpt_gap"
+	GptGap           string   `yaml:"gpt_gap"`
 	Partitions       []Partition
 	Mountpoints      []Mountpoint
 	size             int64

--- a/actions/image_partition_action.go
+++ b/actions/image_partition_action.go
@@ -639,7 +639,7 @@ func (i ImagePartitionAction) Run(context *debos.DebosContext) error {
 
 		devicePath := i.getPartitionDevice(p.number, *context)
 		context.ImagePartitions = append(context.ImagePartitions,
-			debos.Partition{p.Name, devicePath})
+			debos.Partition{Name: p.Name, DevicePath: devicePath})
 	}
 
 	context.ImageMntDir = path.Join(context.Scratchdir, "mnt")

--- a/actions/image_partition_action.go
+++ b/actions/image_partition_action.go
@@ -215,7 +215,7 @@ type Partition struct {
 	Flags           []string
 	Features        []string
 	ExtendedOptions []string
-	Fsck            bool   `yaml:"fsck"`
+	Fsck            bool `yaml:"fsck"`
 	FSUUID          string
 }
 
@@ -250,7 +250,7 @@ type ImagePartitionAction struct {
 	ImageSize        string
 	PartitionType    string
 	DiskID           string
-	GptGap           string   `yaml:"gpt_gap"`
+	GptGap           string `yaml:"gpt_gap"`
 	Partitions       []Partition
 	Mountpoints      []Mountpoint
 	size             int64

--- a/actions/ostree_deploy_action.go
+++ b/actions/ostree_deploy_action.go
@@ -64,7 +64,7 @@ import (
 type OstreeDeployAction struct {
 	debos.BaseAction    `yaml:",inline"`
 	Repository          string
-	RemoteRepository    string   `yaml:"remote_repository"`
+	RemoteRepository    string `yaml:"remote_repository"`
 	Branch              string
 	Os                  string
 	SetupFSTab          bool   `yaml:"setup-fstab"`

--- a/actions/ostree_deploy_action.go
+++ b/actions/ostree_deploy_action.go
@@ -64,7 +64,7 @@ import (
 type OstreeDeployAction struct {
 	debos.BaseAction    `yaml:",inline"`
 	Repository          string
-	RemoteRepository    string "remote_repository"
+	RemoteRepository    string   `yaml:"remote_repository"`
 	Branch              string
 	Os                  string
 	SetupFSTab          bool   `yaml:"setup-fstab"`

--- a/actions/recipe_test.go
+++ b/actions/recipe_test.go
@@ -308,9 +308,9 @@ actions:
 func runTestWithSubRecipes(t *testing.T, test testSubRecipe, templateVars ...map[string]string) actions.Recipe {
 	context := debos.DebosContext{
 		CommonContext: &debos.CommonContext{},
-		RecipeDir: "",
-		Architecture: "",
-		SectorSize: 512,
+		RecipeDir:     "",
+		Architecture:  "",
+		SectorSize:    512,
 	}
 	dir, err := os.MkdirTemp("", "go-debos")
 	assert.Empty(t, err)

--- a/actions/recipe_test.go
+++ b/actions/recipe_test.go
@@ -306,7 +306,12 @@ actions:
 }
 
 func runTestWithSubRecipes(t *testing.T, test testSubRecipe, templateVars ...map[string]string) actions.Recipe {
-	context := debos.DebosContext{&debos.CommonContext{}, "", "", 512}
+	context := debos.DebosContext{
+		CommonContext: &debos.CommonContext{},
+		RecipeDir: "",
+		Architecture: "",
+		SectorSize: 512,
+	}
 	dir, err := os.MkdirTemp("", "go-debos")
 	assert.Empty(t, err)
 	defer os.RemoveAll(dir)

--- a/cmd/debos/debos.go
+++ b/cmd/debos/debos.go
@@ -96,9 +96,9 @@ func warnLocalhost(variable string, value string) {
 func main() {
 	context := debos.DebosContext{
 		CommonContext: &debos.CommonContext{},
-		RecipeDir: "",
-		Architecture: "",
-		SectorSize: 512,
+		RecipeDir:     "",
+		Architecture:  "",
+		SectorSize:    512,
 	}
 	var options struct {
 		Backend            string            `short:"b" long:"fakemachine-backend" description:"Fakemachine backend to use" default:"auto"`

--- a/cmd/debos/debos.go
+++ b/cmd/debos/debos.go
@@ -94,7 +94,12 @@ func warnLocalhost(variable string, value string) {
 }
 
 func main() {
-	context := debos.DebosContext{&debos.CommonContext{}, "", "", 512}
+	context := debos.DebosContext{
+		CommonContext: &debos.CommonContext{},
+		RecipeDir: "",
+		Architecture: "",
+		SectorSize: 512,
+	}
 	var options struct {
 		Backend            string            `short:"b" long:"fakemachine-backend" description:"Fakemachine backend to use" default:"auto"`
 		ArtifactDir        string            `long:"artifactdir" description:"Directory for packed archives and ostree repositories (default: current directory)"`


### PR DESCRIPTION
Enable govet static checks
- **fix: struct field tag not compatible with reflect.StructTag.Get**
- **fix: struct literal uses unkeyed fields**
- **ci: Enable govet linter in golangci.yml**
