### PR TITLE
commands: systemd-nspawn: randomize machine name

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"math/rand"
 	"os"
 	"os/exec"
 	"path"
@@ -231,6 +232,7 @@ func (cmd Command) Run(label string, cmdline ...string) error {
 		options = append(options, "--resolv-conf=off")
 		options = append(options, "--timezone=off")
 		options = append(options, "--register=no")
+		options = append(options, fmt.Sprintf("--machine=debos-%d", rand.Int63()))
 		options = append(options, "--keep-unit")
 		options = append(options, "--console=pipe")
 		for _, e := range cmd.extraEnv {


### PR DESCRIPTION
When you have multiple debos chroot builds running at the same time, you will get something like this:

	2025/09/16 11:17:38 apt | Mount point '/run/systemd/nspawn/unix-export/root' exists already, refusing.
	2025/09/16 11:17:38 Action `recipe` failed at stage Run, error: exit status 1

This because systemd-nspawn will name the container acc. to the root directory per default, which is always "root" for debos, and wants to create a subdir inside "/run/systemd/nspawn/unix-export" even with "--register=no".

To reproduce this problem, you need two copies of a root file system where the last component of the path has the same name.

The example below was run on Debian Trixie arm64 and uses ~/trixie1/trixie and ~/trixie2/trixie as the root directories:

	1st terminal:

	root@jaguar1:~/trixie1/trixie# systemd-nspawn --register=no bash
	░ Spawning container trixie on /root/trixie1/trixie.
	░ Press Ctrl-] three times within 1s to kill container.
	root@trixie:/#

	2nd terminal:

	root@jaguar1:~/trixie2/trixie# systemd-nspawn --register=no bash
	░ Spawning container trixie on /root/trixie2/trixie.
	░ Press Ctrl-] three times within 1s to kill container.
	Mount point '/run/systemd/nspawn/unix-export/trixie' exists already, refusing.
	# Try again
	root@jaguar1:~/trixie2/trixie# systemd-nspawn --register=no bash
	░ Spawning container trixie on /root/trixie2/trixie.
	░ Press Ctrl-] three times within 1s to kill container.
	Failed to allocate scope: Unit trixie.scope was already loaded or has a fragment file.

To fix this we problem, set the container name via "--machine" to debos-NNNNN, where NNNNN is a random int63.

This makes name collisions virtually impossible and fixes the problem.