### PR TITLE
Use Verify to check required commands are present

### DIFF
--- a/action.go
+++ b/action.go
@@ -54,8 +54,12 @@ func (c *Context) Origin(o string) (string, bool) {
 }
 
 type Action interface {
+	// Verify runs first
 	/* FIXME verify should probably be prepare or somesuch */
 	Verify(context *Context) error
+	// CheckEnvironment runs in the environment that Run will execute in,
+	// prior to Run commencing
+	CheckEnvironment(context *Context) error
 	PreMachine(context *Context, m *fakemachine.Machine, args *[]string) error
 	PreNoMachine(context *Context) error
 	Run(context *Context) error
@@ -74,7 +78,8 @@ type BaseAction struct {
 	Description string
 }
 
-func (b *BaseAction) Verify(_ *Context) error { return nil }
+func (b *BaseAction) Verify(_ *Context) error           { return nil }
+func (b *BaseAction) CheckEnvironment(_ *Context) error { return nil }
 func (b *BaseAction) PreMachine(_ *Context,
 	_ *fakemachine.Machine,
 	_ *[]string) error {

--- a/actions/debootstrap_action.go
+++ b/actions/debootstrap_action.go
@@ -127,6 +127,15 @@ func (d *DebootstrapAction) Verify(context *debos.Context) error {
 	return nil
 }
 
+func (d *DebootstrapAction) CheckEnvironment(_ *debos.Context) error {
+	// Check that debootstrap is available
+	cmd := debos.Command{}
+	if err := cmd.CheckExecutableExists("debootstrap"); err != nil {
+		return err
+	}
+	return nil
+}
+
 func (d *DebootstrapAction) PreMachine(context *debos.Context, m *fakemachine.Machine, _ *[]string) error {
 	mounts := d.listOptionFiles(context)
 

--- a/actions/filesystem_deploy_action.go
+++ b/actions/filesystem_deploy_action.go
@@ -53,6 +53,14 @@ func NewFilesystemDeployAction() *FilesystemDeployAction {
 	return fd
 }
 
+func (fd *FilesystemDeployAction) CheckEnvironment(_ *debos.Context) error {
+	cmd := debos.Command{}
+	if err := cmd.CheckExecutableExists("cp"); err != nil {
+		return err
+	}
+	return nil
+}
+
 func (fd *FilesystemDeployAction) setupFSTab(context *debos.Context) error {
 	if context.ImageFSTab.Len() == 0 {
 		return errors.New("fstab not generated, missing image-partition action?")

--- a/actions/mmdebstrap_action.go
+++ b/actions/mmdebstrap_action.go
@@ -113,6 +113,15 @@ func (d *MmdebstrapAction) Verify(context *debos.Context) error {
 	return nil
 }
 
+func (d *MmdebstrapAction) CheckEnvironment(_ *debos.Context) error {
+	// Check that mmdebstrap is available
+	cmd := debos.Command{}
+	if err := cmd.CheckExecutableExists("mmdebstrap"); err != nil {
+		return err
+	}
+	return nil
+}
+
 func (d *MmdebstrapAction) PreMachine(context *debos.Context, m *fakemachine.Machine, _ *[]string) error {
 	mounts := d.listOptionFiles(context)
 

--- a/actions/ostree_deploy_action.go
+++ b/actions/ostree_deploy_action.go
@@ -81,6 +81,14 @@ func NewOstreeDeployAction() *OstreeDeployAction {
 	return ot
 }
 
+func (ot *OstreeDeployAction) CheckEnvironment(_ *debos.Context) error {
+	cmd := debos.Command{}
+	if err := cmd.CheckExecutableExists("cp"); err != nil {
+		return err
+	}
+	return nil
+}
+
 func (ot *OstreeDeployAction) setupFSTab(deployment *ostree.Deployment, context *debos.Context) error {
 	deploymentDir := fmt.Sprintf("ostree/deploy/%s/deploy/%s.%d",
 		deployment.Osname(), deployment.Csum(), deployment.Deployserial())

--- a/actions/pack_action.go
+++ b/actions/pack_action.go
@@ -71,6 +71,14 @@ func (pf *PackAction) Verify(_ *debos.Context) error {
 		pf.Compression, strings.Join(possibleTypes, ", "))
 }
 
+func (pf *PackAction) CheckEnvironment(_ *debos.Context) error {
+	cmd := debos.Command{}
+	if err := cmd.CheckExecutableExists("tar"); err != nil {
+		return err
+	}
+	return nil
+}
+
 func (pf *PackAction) Run(context *debos.Context) error {
 	usePigz := false
 	if pf.Compression == "gz" {

--- a/actions/recipe_action.go
+++ b/actions/recipe_action.go
@@ -89,6 +89,15 @@ func (recipe *RecipeAction) Verify(context *debos.Context) error {
 	return nil
 }
 
+func (recipe *RecipeAction) CheckEnvironment(_ *debos.Context) error {
+	for _, a := range recipe.Actions.Actions {
+		if err := a.CheckEnvironment(&recipe.context); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func (recipe *RecipeAction) PreMachine(_ *debos.Context, m *fakemachine.Machine, args *[]string) error {
 	// TODO: check args?
 

--- a/commands.go
+++ b/commands.go
@@ -289,6 +289,18 @@ func (cmd Command) Run(label string, cmdline ...string) error {
 	return nil
 }
 
+func (cmd Command) CheckExecutableExists(cmdline ...string) error {
+	if len(cmdline) == 0 {
+		return fmt.Errorf("no command provided")
+	}
+	name := cmdline[0]
+	_, err := exec.LookPath(name)
+	if err != nil {
+		return fmt.Errorf("%w", err)
+	}
+	return nil
+}
+
 type qemuHelper struct {
 	qemusrc    string
 	qemutarget string


### PR DESCRIPTION
For each action, check that as many commands it needs are available as possible. This can't be meaningfully extended to commands that run in the chroot, or might run in the chroot.

This follows up from comments on https://github.com/go-debos/debos/pull/276 which were captured as issue https://github.com/go-debos/debos/issues/280.

Closes: https://github.com/go-debos/debos/issues/280

Based on: https://github.com/go-debos/debos/pull/283