### PR TITLE
Docker: Speed up runner builds by avoiding initramfs

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -37,6 +37,10 @@ RUN /get-archlinux-keyring.sh /arch-keyring
 ### second stage - runner ###
 FROM debian:bookworm-slim AS runner-amd64
 RUN apt-get update && \
+    apt-get install -y --no-install-recommends initramfs-tools && \
+    rm -rf /var/lib/apt/lists/*
+RUN rm /etc/kernel/postinst.d/*
+RUN apt-get update && \
     apt-get install -y --no-install-recommends \
         linux-image-amd64 \
         qemu-system-x86 \
@@ -44,6 +48,10 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 FROM debian:bookworm-slim AS runner-arm64
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends initramfs-tools && \
+    rm -rf /var/lib/apt/lists/*
+RUN rm /etc/kernel/postinst.d/*
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
         linux-image-arm64 \


### PR DESCRIPTION
The runner images install a kernel, which pulls in initramfs-tools to create an initramfs. For debos we don't need to have an initramfs, we just need the kernel image. Generating this on the native architecture (amd64) is reasonably fast. However in emulation, when building for arm64, this is *very* slow.

In current github actions this change seems to save about 20 minutes per docker build. For PR triggered runs this (which don't upload the containers) this should save 20 minutes end-to-end (one build on the critical path), while for runs that do it should save about 40 minutes end to end (three builds, of which 2 on the critical path).