### PR TITLE
https by default

### DIFF
--- a/actions/debootstrap_action.go
+++ b/actions/debootstrap_action.go
@@ -27,7 +27,7 @@ Optional properties:
 - check-gpg -- verify GPG signatures on Release files, true by default
 
   - mirror -- URL with Debian-compatible repository
-    If no mirror is specified debos will use http://deb.debian.org/debian as default.
+    If no mirror is specified, debootstrap will use its default mirror.
 
 - variant -- name of the bootstrap script variant to use
 
@@ -84,8 +84,6 @@ func NewDebootstrapAction() *DebootstrapAction {
 	d.CheckGpg = true
 	// Use main as default component
 	d.Components = []string{"main"}
-	// Set generic default mirror
-	d.Mirror = "http://deb.debian.org/debian"
 
 	return &d
 }

--- a/actions/debootstrap_action.go
+++ b/actions/debootstrap_action.go
@@ -181,7 +181,12 @@ func (d *DebootstrapAction) isLikelyOldSuite() bool {
 	}
 }
 
-func (d *DebootstrapAction) Run(context *debos.Context) error {
+func isForeignArch(context *debos.Context) bool {
+	/* Only works for amd64, arm64 and riscv64 hosts, which should be enough */
+	return context.Architecture != runtime.GOARCH
+}
+
+func (d *DebootstrapAction) BuildDebootstrapCommand(context *debos.Context) []string {
 	cmdline := []string{"debootstrap"}
 
 	if d.MergedUsr {
@@ -213,10 +218,7 @@ func (d *DebootstrapAction) Run(context *debos.Context) error {
 		cmdline = append(cmdline, fmt.Sprintf("--components=%s", s))
 	}
 
-	/* Only works for amd64, arm64 and riscv64 hosts, which should be enough */
-	foreign := context.Architecture != runtime.GOARCH
-
-	if foreign {
+	if isForeignArch(context) {
 		cmdline = append(cmdline, "--foreign")
 		cmdline = append(cmdline, fmt.Sprintf("--arch=%s", context.Architecture))
 	}
@@ -236,6 +238,12 @@ func (d *DebootstrapAction) Run(context *debos.Context) error {
 	cmdline = append(cmdline, d.Mirror)
 	cmdline = append(cmdline, "/usr/share/debootstrap/scripts/unstable")
 
+	return cmdline
+}
+
+func (d *DebootstrapAction) Run(context *debos.Context) error {
+	cmdline := d.BuildDebootstrapCommand(context)
+
 	/* Make sure /etc/apt/apt.conf.d exists inside the fakemachine otherwise
 	   debootstrap prints a warning about the path not existing. */
 	if fakemachine.InMachine() {
@@ -252,7 +260,7 @@ func (d *DebootstrapAction) Run(context *debos.Context) error {
 		return err
 	}
 
-	if foreign {
+	if isForeignArch(context) {
 		err = d.RunSecondStage(*context)
 		if err != nil {
 			return err

--- a/actions/debootstrap_action.go
+++ b/actions/debootstrap_action.go
@@ -52,7 +52,6 @@ package actions
 
 import (
 	"fmt"
-	"io"
 	"log"
 	"os"
 	"path"
@@ -266,21 +265,6 @@ func (d *DebootstrapAction) Run(context *debos.Context) error {
 			return err
 		}
 	}
-
-	/* HACK */
-	srclist, err := os.OpenFile(path.Join(context.Rootdir, "etc/apt/sources.list"),
-		os.O_RDWR|os.O_CREATE, 0755)
-	if err != nil {
-		return err
-	}
-	_, err = io.WriteString(srclist, fmt.Sprintf("deb %s %s %s\n",
-		d.Mirror,
-		d.Suite,
-		strings.Join(d.Components, " ")))
-	if err != nil {
-		return err
-	}
-	srclist.Close()
 
 	/* Cleanup resolv.conf after debootstrap */
 	resolvconf := path.Join(context.Rootdir, "/etc/resolv.conf")

--- a/actions/debootstrap_action_test.go
+++ b/actions/debootstrap_action_test.go
@@ -65,5 +65,6 @@ func TestDebootstrapAction_Mirror_Default(t *testing.T) {
 
 	cmdline := action.BuildDebootstrapCommand(context)
 
-	assert.Contains(t, cmdline, "https://deb.debian.org/debian")
+	// empty mirror means to to use the default
+	assert.Contains(t, cmdline, "")
 }

--- a/actions/debootstrap_action_test.go
+++ b/actions/debootstrap_action_test.go
@@ -1,0 +1,69 @@
+package actions_test
+
+import (
+	"runtime"
+	"testing"
+
+	"github.com/go-debos/debos"
+	"github.com/go-debos/debos/actions"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDebootstrapAction_Components_Multiple(t *testing.T) {
+	context := &debos.Context{
+		CommonContext: &debos.CommonContext{},
+		Architecture:  runtime.GOARCH,
+	}
+
+	action := actions.NewDebootstrapAction()
+	action.Suite = "trixie"
+	action.Mirror = "https://deb.debian.org/debian"
+	action.Components = []string{"main", "contrib", "non-free"}
+
+	cmdline := action.BuildDebootstrapCommand(context)
+
+	assert.Contains(t, cmdline, "--components=main,contrib,non-free")
+}
+
+func TestDebootstrapAction_Components_Default(t *testing.T) {
+	context := &debos.Context{
+		CommonContext: &debos.CommonContext{},
+		Architecture:  runtime.GOARCH,
+	}
+
+	action := actions.NewDebootstrapAction()
+	action.Suite = "trixie"
+
+	cmdline := action.BuildDebootstrapCommand(context)
+
+	assert.Contains(t, cmdline, "--components=main")
+}
+
+func TestDebootstrapAction_Mirror_Custom(t *testing.T) {
+	context := &debos.Context{
+		CommonContext: &debos.CommonContext{},
+		Architecture:  runtime.GOARCH,
+	}
+
+	action := actions.NewDebootstrapAction()
+	action.Suite = "trixie"
+	action.Mirror = "https://example.com/debian"
+
+	cmdline := action.BuildDebootstrapCommand(context)
+
+	assert.Contains(t, cmdline, "https://example.com/debian")
+}
+
+func TestDebootstrapAction_Mirror_Default(t *testing.T) {
+	context := &debos.Context{
+		CommonContext: &debos.CommonContext{},
+		Architecture:  runtime.GOARCH,
+	}
+
+	action := actions.NewDebootstrapAction()
+	action.Suite = "trixie"
+
+	cmdline := action.BuildDebootstrapCommand(context)
+
+	assert.Contains(t, cmdline, "https://deb.debian.org/debian")
+}

--- a/actions/download_action.go
+++ b/actions/download_action.go
@@ -5,7 +5,7 @@ Download a single file from Internet and unpack it in place if needed.
 
 	# Yaml syntax:
 	- action: download
-	  url: http://example.domain/path/filename.ext
+	  url: https://example.org/path/filename.ext
 	  name: firmware
 	  filename: output_name
 	  unpack: bool

--- a/actions/image_partition_action.go
+++ b/actions/image_partition_action.go
@@ -441,7 +441,7 @@ func (i ImagePartitionAction) formatPartition(p *Partition, context debos.Contex
 		/* Some underlying device driver, e.g. the UML UBD driver, may manage holes
 		 * incorrectly which will prevent to retrieve all useful zero ranges in
 		 * filesystem, e.g. when using 'bmaptool create', see patch
-		 * http://lists.infradead.org/pipermail/linux-um/2022-January/002074.html
+		 * https://lists.infradead.org/pipermail/linux-um/2022-January/002074.html
 		 *
 		 * Adding UNIX_IO_NOZEROOUT environment variable prevent mkfs.ext[234]
 		 * utilities to create zero range spaces using fallocate with

--- a/actions/install_deb_action.go
+++ b/actions/install_deb_action.go
@@ -55,7 +55,7 @@ Example to download and install a package:
 
  - action: download
    description: Install Debian package from url
-   url: http://ftp.us.debian.org/debian/pool/main/b/bmap-tools/bmap-tools_3.5-2_all.deb
+   url: https://deb.debian.org/debian/pool/main/b/bmap-tools/bmaptool_3.9.0-3_all.deb
    name: bmap-tools-pkg
 
  - action: install-deb

--- a/actions/mmdebstrap_action.go
+++ b/actions/mmdebstrap_action.go
@@ -26,7 +26,7 @@ Mandatory properties:
 Optional properties:
 
   - mirrors -- list of URLs with Debian-compatible repository
-    If no mirror is specified debos will use http://deb.debian.org/debian as default.
+    If no mirror is specified the default mirror of mmdebstrap will be used.
 
 - variant -- name of the bootstrap script variant to use
 

--- a/tests/sources-list-custom/test.yaml
+++ b/tests/sources-list-custom/test.yaml
@@ -1,0 +1,27 @@
+---
+# Test sources.list generation with debootstrap action using explicit
+# mirror and components settings
+{{- $architecture := or .architecture "amd64"}}
+{{- $suite := or .suite "bookworm"}}
+{{- $tool := or .tool "debootstrap" }}
+{{- $mirror := or .mirror "https://deb.debian.org/debian" }}
+architecture: {{$architecture}}
+
+actions:
+  - action: {{ $tool }}
+    suite: {{ $suite }}
+    variant: minbase
+    merged-usr: true
+    mirror: {{ $mirror }}
+    components:
+      - main
+      - contrib
+
+  - action: run
+    description: Verify sources.list contains the correct mirror and components
+    chroot: true
+    command: >
+      grep -q "^deb {{ $mirror }} {{ $suite }} main contrib" /etc/apt/sources.list ||
+      (echo "ERROR: sources.list does not contain expected entry:" &&
+       cat /etc/apt/sources.list &&
+       exit 1)

--- a/tests/sources-list-default/test.yaml
+++ b/tests/sources-list-default/test.yaml
@@ -12,10 +12,10 @@ actions:
     merged-usr: true
 
   - action: run
-    description: Verify sources.list contains the default mirror and main component
+    description: Verify sources.list contains the expected default component
     chroot: true
     command: >
-      grep -q "^deb https://deb.debian.org/debian {{ $suite }} main" /etc/apt/sources.list ||
-      (echo "ERROR: sources.list does not contain expected default entry:" &&
+      grep -q "^deb .* {{ $suite }} main" /etc/apt/sources.list ||
+      (echo "ERROR: sources.list does not contain expected entry with main component:" &&
        cat /etc/apt/sources.list &&
        exit 1)

--- a/tests/sources-list-default/test.yaml
+++ b/tests/sources-list-default/test.yaml
@@ -1,0 +1,21 @@
+---
+# Test sources.list generation with debootstrap action using defaults
+{{- $architecture := or .architecture "amd64"}}
+{{- $suite := or .suite "bookworm"}}
+{{- $tool := or .tool "debootstrap" }}
+architecture: {{$architecture}}
+
+actions:
+  - action: {{ $tool }}
+    suite: {{ $suite }}
+    variant: minbase
+    merged-usr: true
+
+  - action: run
+    description: Verify sources.list contains the default mirror and main component
+    chroot: true
+    command: >
+      grep -q "^deb https://deb.debian.org/debian {{ $suite }} main" /etc/apt/sources.list ||
+      (echo "ERROR: sources.list does not contain expected default entry:" &&
+       cat /etc/apt/sources.list &&
+       exit 1)


### PR DESCRIPTION
This avoids using https where we can and hardcoding the default mirror for debootstrap.
- **refactor(debootstrap_action): No default mirror**
- **refactor(debootstrap_action): Drop APT sources gen**
- **refactor(debootstrap_action): Add unit tests**
- **tests: Add integration tests for debootstrap**
- **fix: Use https links where possible**
- **refactor: Clarify default mirror for mmdebstrap**

The only remaining file with http:// URLs is the Apache 2.0 license, but it's probably a bad idea to patch it for compliance tooling to work.