### PR TITLE
tests: use "missing" instead of "non-existent"

### DIFF
--- a/actions/raw_action_test.go
+++ b/actions/raw_action_test.go
@@ -146,9 +146,9 @@ func TestRawAction_InvalidOrigin(t *testing.T) {
 		SectorSize:   512,
 	}
 
-	// Test case: Raw action with non-existent origin should fail
+	// Test case: Raw action with missing origin should fail
 	action := actions.RawAction{
-		Origin: "non-existent-origin",
+		Origin: "missing-origin",
 		Source: "bootloader.img",
 	}
 
@@ -156,6 +156,6 @@ func TestRawAction_InvalidOrigin(t *testing.T) {
 	assert.NoError(t, err, "Verify should pass (origin is checked at runtime)")
 
 	err = action.Run(context)
-	assert.Error(t, err, "Run should fail with non-existent origin")
-	assert.Contains(t, err.Error(), "origin `non-existent-origin` doesn't exist")
+	assert.Error(t, err, "Run should fail with missing origin")
+	assert.Contains(t, err.Error(), "origin `missing-origin` doesn't exist")
 }

--- a/tests/exit_test/exit_test.sh
+++ b/tests/exit_test/exit_test.sh
@@ -56,7 +56,7 @@ expect_failure debos --not-a-valid-option
 expect_failure debos
 expect_failure debos good.yaml good.yaml
 expect_failure debos --disable-fakemachine --fakemachine-backend=qemu good.yaml
-expect_failure debos non-existent-file.yaml
+expect_failure debos missing-file.yaml
 expect_failure debos garbled.yaml
 expect_failure debos --fakemachine-backend=kvm good.yaml
 expect_failure debos verify-fail.yaml
@@ -67,11 +67,11 @@ expect_success debos good.yaml
 expect_failure debos bad.yaml
 expect_failure debos pre-machine-failure.yaml
 expect_failure debos post-machine-failure.yaml
-expect_failure debos overlay-non-existent-destination.yaml
-expect_failure debos overlay-non-existent-source.yaml
+expect_failure debos overlay-missing-destination.yaml
+expect_failure debos overlay-missing-source.yaml
 expect_failure rename_command NOT_DEBOS debos good.yaml
 
-expect_failure $SUDO debos non-existent-file.yaml --disable-fakemachine
+expect_failure $SUDO debos missing-file.yaml --disable-fakemachine
 expect_failure $SUDO debos garbled.yaml --disable-fakemachine
 expect_failure $SUDO debos verify-fail.yaml --disable-fakemachine
 expect_success $SUDO debos --dry-run good.yaml --disable-fakemachine
@@ -79,8 +79,8 @@ expect_success $SUDO debos good.yaml --disable-fakemachine
 expect_failure $SUDO debos bad.yaml --disable-fakemachine
 expect_failure $SUDO debos pre-machine-failure.yaml --disable-fakemachine
 expect_failure $SUDO debos post-machine-failure.yaml --disable-fakemachine
-expect_failure $SUDO debos overlay-non-existent-destination.yaml --disable-fakemachine
-expect_failure $SUDO debos overlay-non-existent-source.yaml --disable-fakemachine
+expect_failure $SUDO debos overlay-missing-destination.yaml --disable-fakemachine
+expect_failure $SUDO debos overlay-missing-source.yaml --disable-fakemachine
 
 echo
 if [[ $FAILURES -ne 0 ]]; then

--- a/tests/exit_test/overlay-missing-destination.yaml
+++ b/tests/exit_test/overlay-missing-destination.yaml
@@ -1,0 +1,9 @@
+architecture: amd64
+
+actions:
+  # This overlay action is expected to error out because the destination
+  # doesn't exist in the filesystem.
+  - action: overlay
+    description: Overlay file into a missing destination
+    source: overlay-missing-destination.yaml
+    destination: /this/path/does/not/exist/overlay-missing-destination.yaml

--- a/tests/exit_test/overlay-missing-source.yaml
+++ b/tests/exit_test/overlay-missing-source.yaml
@@ -2,7 +2,7 @@ architecture: amd64
 
 actions:
   # This overlay action is expected to error out here because the source
-  # doesn't exist in the recipe directory.
+  # is missing in the recipe directory.
   - action: overlay
     description: Overlay missing file
     source: missing-file

--- a/tests/exit_test/overlay-non-existent-destination.yaml
+++ b/tests/exit_test/overlay-non-existent-destination.yaml
@@ -1,9 +1,0 @@
-architecture: amd64
-
-actions:
-  # This overlay action is expected to error out because the destination
-  # doesn't exist in the filesystem.
-  - action: overlay
-    description: Overlay file into a non-existent destination
-    source: overlay-non-existent-destination.yaml
-    destination: /this/path/does/not/exist/overlay-non-existent-destination.yaml


### PR DESCRIPTION
Replace uses of the phrase "non-existent" in test names and messages with "missing" which is more grammatically natural and commonly used when referring to files or resources.

This patch introduces no functional changes.