### PR TITLE
actions: overlay: verify either source or origin set

### DIFF
--- a/actions/overlay_action.go
+++ b/actions/overlay_action.go
@@ -25,6 +25,7 @@ If destination isn't set '/' of the rootfs will be used.
 package actions
 
 import (
+	"errors"
 	"fmt"
 	"log"
 	"os"
@@ -43,6 +44,10 @@ type OverlayAction struct {
 func (overlay *OverlayAction) Verify(context *debos.Context) error {
 	if _, err := debos.RestrictedPath(context.Rootdir, overlay.Destination); err != nil {
 		return err
+	}
+
+	if len(overlay.Source) == 0 && len(overlay.Origin) == 0 {
+		return errors.New("'source' and 'origin' properties can't both be empty")
 	}
 
 	/* if origin is the recipe, check the path exists on disk */

--- a/tests/exit_test/exit_test.sh
+++ b/tests/exit_test/exit_test.sh
@@ -69,6 +69,7 @@ expect_failure debos pre-machine-failure.yaml
 expect_failure debos post-machine-failure.yaml
 expect_failure debos overlay-missing-destination.yaml
 expect_failure debos overlay-missing-source.yaml
+expect_failure debos overlay-no-source.yaml
 expect_failure rename_command NOT_DEBOS debos good.yaml
 
 expect_failure $SUDO debos missing-file.yaml --disable-fakemachine

--- a/tests/exit_test/overlay-no-source.yaml
+++ b/tests/exit_test/overlay-no-source.yaml
@@ -1,0 +1,7 @@
+architecture: amd64
+
+actions:
+  # This overlay action is expected to error out here because the source
+  # property isn't set
+  - action: overlay
+    description: Overlay without source property


### PR DESCRIPTION
This check avoids accidental overlaying the recipe directory, which the origin defaults to, in case source isn't set.

Fixes: #23