### PR TITLE
actions: mmdebstrap: use lowercase mmdebstrap for command label

### DIFF
--- a/actions/mmdebstrap_action.go
+++ b/actions/mmdebstrap_action.go
@@ -191,7 +191,7 @@ func (d *MmdebstrapAction) Run(context *debos.Context) error {
 		}
 	}
 
-	mmdebstrapErr := debos.Command{}.Run("Mmdebstrap", cmdline...)
+	mmdebstrapErr := debos.Command{}.Run("mmdebstrap", cmdline...)
 
 	/* Cleanup resolv.conf after mmdebstrap */
 	resolvconf := path.Join(context.Rootdir, "/etc/resolv.conf")


### PR DESCRIPTION
The mmdebstrap command currently uses `Mmdebstrap` for the command label which doesn't match other actions:

    2026/01/23 21:44:43 ==== mmdebstrap ====
    2026/01/23 21:44:43 Mmdebstrap | I: automatically chosen mode: root
    2026/01/23 21:44:43 Mmdebstrap | I: chroot architecture amd64 is equal to the host's architecture
    2026/01/23 21:44:43 Mmdebstrap | I: automatically chosen format: directory
    2026/01/23 21:44:43 Mmdebstrap | I: running apt-get update...
    2026/01/23 21:44:45 Mmdebstrap | I: downloading packages with apt...
    2026/01/23 21:44:46 Mmdebstrap | I: extracting archives...
    2026/01/23 21:44:47 Mmdebstrap | I: installing essential packages...
    2026/01/23 21:44:48 Mmdebstrap | I: installing remaining packages inside the chroot...
    2026/01/23 21:44:50 Mmdebstrap | I: cleaning package lists and apt cache...
    2026/01/23 21:44:50 Mmdebstrap | I: success in 6.8942 seconds

Use a label which is all lowercase to match all other actions.

--

I know this is a bit pedantic, but the lowercase label pleases me :-)