### PR TITLE
recipe: yaml: Disallow unknown action properties

### DIFF
--- a/actions/recipe.go
+++ b/actions/recipe.go
@@ -115,14 +115,18 @@ type Recipe struct {
 }
 
 func (y *YamlAction) UnmarshalYAML(unmarshal func(interface{}) error) error {
-	var aux debos.BaseAction
+	var raw map[string]interface{}
 
-	err := unmarshal(&aux)
-	if err != nil {
+	if err := unmarshal(&raw); err != nil {
 		return err
 	}
 
-	switch aux.Action {
+	action, ok := raw["action"].(string)
+	if !ok || action == "" {
+		return fmt.Errorf("missing or invalid 'action' field")
+	}
+
+	switch action {
 	case "debootstrap":
 		y.Action = NewDebootstrapAction()
 	case "mmdebstrap":
@@ -158,10 +162,10 @@ func (y *YamlAction) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	case "recipe":
 		y.Action = &RecipeAction{}
 	default:
-		return fmt.Errorf("unknown action: %v", aux.Action)
+		return fmt.Errorf("unknown action: %v", action)
 	}
 
-	err = unmarshal(y.Action)
+	err := unmarshal(y.Action)
 	if err != nil {
 		return err
 	}
@@ -306,7 +310,14 @@ func (r *Recipe) Parse(file string, printRecipe bool, dump bool, templateVars ..
 		log.Printf("%s", data)
 	}
 
-	if err := yaml.Unmarshal(data.Bytes(), r); err != nil {
+	// Disallow unknown fields (e.g. those which are not actually available in an action)
+	// but allow fields prefixed with "." which is useful for YAML anchors in the top-level.
+	if err := yaml.UnmarshalWithOptions(
+		data.Bytes(),
+		r,
+		yaml.DisallowUnknownField(),
+		yaml.AllowFieldPrefixes("."),
+	); err != nil {
 		return err
 	}
 

--- a/actions/recipe.go
+++ b/actions/recipe.go
@@ -127,14 +127,18 @@ type Recipe struct {
 }
 
 func (y *YamlAction) UnmarshalYAML(unmarshal func(interface{}) error) error {
-	var aux debos.BaseAction
+	var raw map[string]interface{}
 
-	err := unmarshal(&aux)
-	if err != nil {
+	if err := unmarshal(&raw); err != nil {
 		return err
 	}
 
-	switch aux.Action {
+	action, ok := raw["action"].(string)
+	if !ok || action == "" {
+		return fmt.Errorf("missing or invalid 'action' field")
+	}
+
+	switch action {
 	case "debootstrap":
 		y.Action = NewDebootstrapAction()
 	case "mmdebstrap":
@@ -170,10 +174,10 @@ func (y *YamlAction) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	case "recipe":
 		y.Action = &RecipeAction{}
 	default:
-		return fmt.Errorf("unknown action: %v", aux.Action)
+		return fmt.Errorf("unknown action: %v", action)
 	}
 
-	err = unmarshal(y.Action)
+	err := unmarshal(y.Action)
 	if err != nil {
 		return err
 	}
@@ -318,7 +322,14 @@ func (r *Recipe) Parse(file string, printRecipe bool, dump bool, templateVars ..
 		log.Printf("%s", data)
 	}
 
-	if err := yaml.Unmarshal(data.Bytes(), r); err != nil {
+	// Disallow unknown fields (e.g. those which are not actually available in an action)
+	// but allow fields prefixed with "." which is useful for YAML anchors in the top-level.
+	if err := yaml.UnmarshalWithOptions(
+		data.Bytes(),
+		r,
+		yaml.DisallowUnknownField(),
+		yaml.AllowFieldPrefixes("."),
+	); err != nil {
 		return err
 	}
 

--- a/actions/recipe_action.go
+++ b/actions/recipe_action.go
@@ -35,6 +35,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"strings"
 )
 
 type RecipeAction struct {
@@ -73,7 +74,14 @@ func (recipe *RecipeAction) Verify(context *debos.Context) error {
 	}
 
 	if err := recipe.Actions.Parse(file, context.PrintRecipe, context.Verbose, recipe.templateVars); err != nil {
-		return err
+		// TODO: possibly do this in the caller?
+		// err contains multiple lines - log them individually to retain timestamp
+		log.Println("Recipe parsing failed:")
+		for _, line := range strings.Split(strings.TrimRight(err.Error(), "\n"), "\n") {
+			log.Printf("%s", line)
+		}
+
+		return fmt.Errorf("recipe parsing failed")
 	}
 
 	if recipe.context.Architecture != recipe.Actions.Architecture {

--- a/cmd/debos/debos.go
+++ b/cmd/debos/debos.go
@@ -195,7 +195,12 @@ func main() {
 		return
 	}
 	if err := r.Parse(file, options.PrintRecipe, options.Verbose, options.TemplateVars); err != nil {
-		log.Println(err)
+		// err contains multiple lines - log them individually to retain timestamp
+		log.Println("Recipe parsing failed:")
+		for _, line := range strings.Split(strings.TrimRight(err.Error(), "\n"), "\n") {
+			log.Printf("%s", line)
+		}
+
 		context.State = debos.Failed
 		return
 	}

--- a/cmd/debos/debos.go
+++ b/cmd/debos/debos.go
@@ -198,7 +198,12 @@ func main() {
 		return
 	}
 	if err := r.Parse(file, options.PrintRecipe, options.Verbose, options.TemplateVars); err != nil {
-		log.Println(err)
+		// err contains multiple lines - log them individually to retain timestamp
+		log.Println("Recipe parsing failed:")
+		for _, line := range strings.Split(strings.TrimRight(err.Error(), "\n"), "\n") {
+			log.Printf("%s", line)
+		}
+
 		context.State = debos.Failed
 		return
 	}

--- a/tests/exit_test/exit_test.sh
+++ b/tests/exit_test/exit_test.sh
@@ -89,6 +89,8 @@ expect_failure $SUDO debos post-machine-failure.yaml --disable-fakemachine
 expect_failure $SUDO debos overlay-missing-source.yaml --disable-fakemachine
 expect_failure $SUDO debos overlay-no-source.yaml --disable-fakemachine
 expect_success $SUDO debos overlay-create-destination.yaml --disable-fakemachine
+expect_failure $SUDO debos unknown-property.yaml --disable-fakemachine
+expect_failure $SUDO debos unknown-property-recipe.yaml --disable-fakemachine
 
 echo
 if [[ $FAILURES -ne 0 ]]; then

--- a/tests/exit_test/unknown-property-recipe.yaml
+++ b/tests/exit_test/unknown-property-recipe.yaml
@@ -1,0 +1,7 @@
+architecture: amd64
+
+# This test ensures that the YAML parsing errors out when an unknown property is set in a child recipe.
+
+actions:
+  - action: recipe
+    recipe: unknown-property.yaml

--- a/tests/exit_test/unknown-property.yaml
+++ b/tests/exit_test/unknown-property.yaml
@@ -1,0 +1,7 @@
+architecture: amd64
+
+# This test ensures that the YAML parsing errors out when an unknown property is set.
+
+actions:
+  - action: run
+    unknown-property: value


### PR DESCRIPTION
Currently the YAML parser allows any property to be set in an action which can cause confusion as Debos will happily execute a recipe with any property set in an action (e.g. generative AI will happily create Debos recipes with wild, hallucinated properties).

Enable strict YAML decoding so recipes fail early when unknown or misspelled properties are present in actions, preventing silent misconfiguration of actions.

Also apply the same validation to the recipe action so that included recipes are also checked for missing action properties.

The YAML parser even logs where a user went wrong:

    [7:5] unknown field "unknown-property"
       5 | actions:
       6 |   - action: run
    >  7 |     unknown-property: value
           ^

Closes: #295