### PR TITLE
doc: fix typo in Debian ospack example

### DIFF
--- a/doc/examples/ospack-debian/ospack-debian.yaml
+++ b/doc/examples/ospack-debian/ospack-debian.yaml
@@ -27,7 +27,7 @@ actions:
     script: scripts/setup-user.sh
 
   - action: overlay
-    descripion: Copy files inside the rootfs
+    description: Copy files inside the rootfs
     source: overlays/sudo
 
   - action: run


### PR DESCRIPTION
Correct a misspelled YAML key `descripion` -> `description`.