### PR TITLE
recipe: Ensure postprocess run actions are at the end of the recipe

### DIFF
--- a/actions/recipe.go
+++ b/actions/recipe.go
@@ -322,6 +322,26 @@ func (r *Recipe) Parse(file string, printRecipe bool, dump bool, templateVars ..
 		return fmt.Errorf("Recipe file must have at least one action")
 	}
 
+	/* ensure all run actions with postprocess set are at the end of the recipe.
+	 * Note: child recipes with postprocess run actions are ran at the end of
+	 * the child recipe execution rather than at the end of the overall recipe
+	 * execution. */
+	seenPostprocessRun := false
+	for _, action := range r.Actions {
+		runAction, isRunAction := action.Action.(*RunAction)
+
+		if seenPostprocessRun {
+			if !isRunAction || !runAction.PostProcess {
+				return fmt.Errorf("postprocess run actions must be at the end of the recipe")
+			}
+			continue
+		}
+
+		if isRunAction && runAction.PostProcess {
+			seenPostprocessRun = true
+		}
+	}
+
 	if r.SectorSize == 0 {
 		r.SectorSize = 512
 	}

--- a/actions/recipe.go
+++ b/actions/recipe.go
@@ -334,6 +334,26 @@ func (r *Recipe) Parse(file string, printRecipe bool, dump bool, templateVars ..
 		return fmt.Errorf("Recipe file must have at least one action")
 	}
 
+	/* ensure all run actions with postprocess set are at the end of the recipe.
+	 * Note: child recipes with postprocess run actions are ran at the end of
+	 * the child recipe execution rather than at the end of the overall recipe
+	 * execution. */
+	seenPostprocessRun := false
+	for _, action := range r.Actions {
+		runAction, isRunAction := action.Action.(*RunAction)
+
+		if seenPostprocessRun {
+			if !isRunAction || !runAction.PostProcess {
+				return fmt.Errorf("postprocess run actions must be at the end of the recipe")
+			}
+			continue
+		}
+
+		if isRunAction && runAction.PostProcess {
+			seenPostprocessRun = true
+		}
+	}
+
 	if r.SectorSize == 0 {
 		r.SectorSize = 512
 	}

--- a/tests/exit_test/exit_test.sh
+++ b/tests/exit_test/exit_test.sh
@@ -89,6 +89,8 @@ expect_failure $SUDO debos post-machine-failure.yaml --disable-fakemachine
 expect_failure $SUDO debos overlay-missing-source.yaml --disable-fakemachine
 expect_failure $SUDO debos overlay-no-source.yaml --disable-fakemachine
 expect_success $SUDO debos overlay-create-destination.yaml --disable-fakemachine
+expect_success $SUDO debos run-postprocess.yaml --disable-fakemachine
+expect_failure $SUDO debos run-postprocess-early.yaml --disable-fakemachine
 
 echo
 if [[ $FAILURES -ne 0 ]]; then

--- a/tests/exit_test/run-postprocess-early.yaml
+++ b/tests/exit_test/run-postprocess-early.yaml
@@ -1,0 +1,19 @@
+architecture: amd64
+
+# Check that postprocess run actions are at the end of the recipe.
+# This recipe should fail to parse, since there is a run action with postprocess
+# not at the end of the recipe.
+
+actions:
+  - action: run
+    description: Run postprocess
+    label: run
+    postprocess: true
+    command: |
+      echo "Run postprocess"
+
+  - action: run
+    description: Run
+    label: run
+    command: |
+      echo "Run"

--- a/tests/exit_test/run-postprocess.yaml
+++ b/tests/exit_test/run-postprocess.yaml
@@ -1,0 +1,17 @@
+architecture: amd64
+
+# Check that postprocess run actions are at the end of the recipe.
+
+actions:
+  - action: run
+    description: Run
+    label: run
+    command: |
+      echo "Run"
+
+  - action: run
+    description: Run postprocess
+    label: run
+    postprocess: true
+    command: |
+      echo "Run postprocess"


### PR DESCRIPTION
Validate that all run actions with `postprocess: true` appear at the
end of the recipe. Once the first postprocess run action is encountered
all remaining actions must also be postprocess run actions otherwise
Parse() returns an error.

Note: postprocess run actions in child recipes execute at the end of the
child recipe, not at the end of the overall recipe.

Closes: https://github.com/go-debos/debos/issues/493