### PR TITLE
ci: Add Ubuntu and Fedora tests && update container image paths

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -71,6 +71,8 @@ jobs:
           - arch
           - debian-trixie
           - debian-forky
+          - ubuntu-questing
+          - fedora-latest
     runs-on: ubuntu-latest
     defaults:
       run:


### PR DESCRIPTION
We now build test-containers for Ubuntu & Fedora. Run the debos test suite on these OSs as well.

Depends on https://github.com/go-debos/test-containers/pull/57