### PR TITLE
ci: Update container image path for golangci job

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,7 +24,7 @@ jobs:
       run:
         shell: bash
     container:
-      image: ghcr.io/go-debos/test-containers/trixie:main
+      image: ghcr.io/go-debos/test-containers/debian-trixie:main
     steps:
     - name: Checkout code
       uses: actions/checkout@v6


### PR DESCRIPTION
The lint job uses the trixie test container and references the old container image without the `debian-` prefix. Update the container image to have the `debian-` prefix.

No functional changes.