### PR TITLE
update debian test to trixie

### DIFF
--- a/tests/debian/test.yaml
+++ b/tests/debian/test.yaml
@@ -1,6 +1,6 @@
 ---
 {{- $architecture := or .architecture "amd64"}}
-{{- $suite := or .suite "bookworm"}}
+{{- $suite := or .suite "trixie"}}
 {{- $tool := or .tool "debootstrap" }}
 architecture: {{$architecture}}
 


### PR DESCRIPTION
Trixie has been stable for a whie now; bump the debian bootstrap test from bookworm to trixie.