### PR TITLE
debos: skip debug shell for postprocess run action failures

### DIFF
--- a/cmd/debos/debos.go
+++ b/cmd/debos/debos.go
@@ -63,6 +63,14 @@ func handleError(context *debos.Context, err error, a debos.Action, stage string
 
 	// Launch a debug shell if a debug shell command is set.
 	if len(context.DebugShell) > 0 {
+		// Don't launch a debug shell for postprocess run actions as there
+		// is no longer a usable shell environment
+		if ya, ok := a.(actions.YamlAction); ok {
+			if run, ok := ya.Action.(*actions.RunAction); ok && run.PostProcess {
+				return true
+			}
+		}
+
 		debos.DebugShell(*context)
 	}
 

--- a/cmd/debos/debos.go
+++ b/cmd/debos/debos.go
@@ -60,7 +60,12 @@ func handleError(context *debos.Context, err error, a debos.Action, stage string
 
 	context.State = debos.Failed
 	log.Printf("Action `%s` failed at stage %s, error: %s", a, stage, err)
-	debos.DebugShell(*context)
+
+	// Launch a debug shell if a debug shell command is set.
+	if len(context.DebugShell) > 0 {
+		debos.DebugShell(*context)
+	}
+
 	return true
 }
 

--- a/cmd/debos/debos.go
+++ b/cmd/debos/debos.go
@@ -61,6 +61,14 @@ func handleError(context *debos.Context, err error, a debos.Action, stage string
 
 	// Launch a debug shell if a debug shell command is set.
 	if len(context.DebugShell) > 0 {
+		// Don't launch a debug shell for postprocess run actions as there
+		// is no longer a usable shell environment
+		if ya, ok := a.(actions.YamlAction); ok {
+			if run, ok := ya.Action.(*actions.RunAction); ok && run.PostProcess {
+				return true
+			}
+		}
+
 		debos.DebugShell(*context)
 	}
 

--- a/cmd/debos/debos.go
+++ b/cmd/debos/debos.go
@@ -58,7 +58,12 @@ func handleError(context *debos.Context, err error, a debos.Action, stage string
 
 	context.State = debos.Failed
 	log.Printf("Action `%s` failed at stage %s, error: %s", a, stage, err)
-	debos.DebugShell(*context)
+
+	// Launch a debug shell if a debug shell command is set.
+	if len(context.DebugShell) > 0 {
+		debos.DebugShell(*context)
+	}
+
 	return true
 }
 

--- a/debug.go
+++ b/debug.go
@@ -11,10 +11,6 @@ DebugShell function launches an interactive shell for
 debug and problems investigation.
 */
 func DebugShell(context Context) {
-	if len(context.DebugShell) == 0 {
-		return
-	}
-
 	pa := os.ProcAttr{
 		Files: []*os.File{os.Stdin, os.Stdout, os.Stderr},
 		Dir:   context.Scratchdir,


### PR DESCRIPTION
When a postprocess run action fails the rootfs is no longer mounted
and there is no usable shell environment for the debug shell to run in.
Skip launching the debug shell in this case.

Fixes: https://github.com/go-debos/debos/issues/503