### PR TITLE
run: pass --environ-var values to non-chroot and postprocess commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,14 +174,13 @@ recipes. Additional more detailed example recipes are stored under [debos-recipe
 ## Environment variables
 
 debos reads a predefined list of environment variables from the host and
-propagates them to the fakemachine build environment. The set of
-environment variables is defined by `environ_vars` in
-`cmd/debos/debos.go`. Currently the list of environment variables includes
-the proxy environment variables documented at:
+propagates them to the build environment. The set of environment variables
+is defined by `environ_vars` in `cmd/debos/debos.go`. Currently the list of
+environment variables includes the proxy environment variables documented at:
 
 https://wiki.archlinux.org/index.php/proxy_settings
 
-The list of environment variables currently exported to fakemachine is:
+The list of environment variables currently exported is:
 
 ```
 http_proxy, https_proxy, ftp_proxy, rsync_proxy, all_proxy, no_proxy
@@ -189,20 +188,21 @@ http_proxy, https_proxy, ftp_proxy, rsync_proxy, all_proxy, no_proxy
 
 While the elements of `environ_vars` are in lower case, for each element
 both lower and upper case variants are probed on the host and if found
-propagated to fakemachine. So if the host has the environment variables
-HTTP_PROXY and no_proxy defined, both will be propagated to fakemachine
-respecting the case.
+are propagated to the build environment. So if the host has the environment
+variables HTTP_PROXY and no_proxy defined, both will be propagated to the build
+environment respecting the case.
 
 The command line options `--environ-var` and `-e` can be used to specify,
-overwrite and unset environment variables for fakemachine with the syntax:
+overwrite and unset environment variables for the build environment with the
+syntax:
 
 ```bash
 debos -e ENVIRONVAR:VALUE ...
 ```
 
 To unset an environment variable, or in other words, to prevent an
-environment variable being propagated to fakemachine, use the same syntax
-without a value. debos accepts multiple -e simultaneously.
+environment variable being propagated to the build environment, use the same
+syntax without a value. debos accepts multiple -e simultaneously.
 
 ## Proxy configuration
 

--- a/README.md
+++ b/README.md
@@ -218,14 +218,13 @@ recipes. Additional more detailed example recipes are stored under [debos-recipe
 ## Environment variables
 
 debos reads a predefined list of environment variables from the host and
-propagates them to the fakemachine build environment. The set of
-environment variables is defined by `environ_vars` in
-`cmd/debos/debos.go`. Currently the list of environment variables includes
-the proxy environment variables documented at:
+propagates them to the build environment. The set of environment variables
+is defined by `environ_vars` in `cmd/debos/debos.go`. Currently the list of
+environment variables includes the proxy environment variables documented at:
 
 https://wiki.archlinux.org/index.php/proxy_settings
 
-The list of environment variables currently exported to fakemachine is:
+The list of environment variables currently exported is:
 
 ```
 http_proxy, https_proxy, ftp_proxy, rsync_proxy, all_proxy, no_proxy
@@ -233,20 +232,21 @@ http_proxy, https_proxy, ftp_proxy, rsync_proxy, all_proxy, no_proxy
 
 While the elements of `environ_vars` are in lower case, for each element
 both lower and upper case variants are probed on the host and if found
-propagated to fakemachine. So if the host has the environment variables
-HTTP_PROXY and no_proxy defined, both will be propagated to fakemachine
-respecting the case.
+are propagated to the build environment. So if the host has the environment
+variables HTTP_PROXY and no_proxy defined, both will be propagated to the build
+environment respecting the case.
 
 The command line options `--environ-var` and `-e` can be used to specify,
-overwrite and unset environment variables for fakemachine with the syntax:
+overwrite and unset environment variables for the build environment with the
+syntax:
 
 ```bash
 debos -e ENVIRONVAR:VALUE ...
 ```
 
 To unset an environment variable, or in other words, to prevent an
-environment variable being propagated to fakemachine, use the same syntax
-without a value. debos accepts multiple -e simultaneously.
+environment variable being propagated to the build environment, use the same
+syntax without a value. debos accepts multiple -e simultaneously.
 
 ## Proxy configuration
 

--- a/actions/run_action.go
+++ b/actions/run_action.go
@@ -124,7 +124,7 @@ func (run *RunAction) doRun(context debos.Context) error {
 	if run.Chroot {
 		cmd = debos.NewChrootCommandForContext(context)
 	} else {
-		cmd = debos.Command{}
+		cmd = debos.NewCommandForContext(context)
 	}
 
 	if run.Script != "" {

--- a/actions/run_action.go
+++ b/actions/run_action.go
@@ -127,7 +127,7 @@ func (run *RunAction) doRun(context debos.Context) error {
 	if run.Chroot {
 		cmd = debos.NewChrootCommandForContext(context)
 	} else {
-		cmd = debos.Command{}
+		cmd = debos.NewCommandForContext(context)
 	}
 
 	if run.Script != "" {

--- a/commands.go
+++ b/commands.go
@@ -68,6 +68,18 @@ func (w *commandWrapper) flush() {
 	w.out(true)
 }
 
+func NewCommandForContext(context Context) Command {
+	c := Command{}
+
+	if context.EnvironVars != nil {
+		for k, v := range context.EnvironVars {
+			c.AddEnv(fmt.Sprintf("%s=%s", k, v))
+		}
+	}
+
+	return c
+}
+
 func NewChrootCommandForContext(context Context) Command {
 	c := Command{Architecture: context.Architecture, Chroot: context.Rootdir, ChrootMethod: ChrootMethodNspawn}
 

--- a/doc/man/debos.1
+++ b/doc/man/debos.1
@@ -206,7 +206,7 @@ debos\-recipes
 \&.
 .SH ENVIRONMENT VARIABLES
 debos reads a predefined list of environment variables from the host and
-propagates them to the fakemachine build environment.
+propagates them to the build environment.
 The set of environment variables is defined by \f[CR]environ_vars\f[R]
 in \f[CR]cmd/debos/debos.go\f[R].
 Currently the list of environment variables includes the proxy
@@ -214,7 +214,7 @@ environment variables documented at:
 .PP
 https://wiki.archlinux.org/index.php/proxy_settings
 .PP
-The list of environment variables currently exported to fakemachine is:
+The list of environment variables currently exported is:
 .IP
 .EX
 http_proxy, https_proxy, ftp_proxy, rsync_proxy, all_proxy, no_proxy
@@ -222,21 +222,22 @@ http_proxy, https_proxy, ftp_proxy, rsync_proxy, all_proxy, no_proxy
 .PP
 While the elements of \f[CR]environ_vars\f[R] are in lower case, for
 each element both lower and upper case variants are probed on the host
-and if found propagated to fakemachine.
+and if found are propagated to the build environment.
 So if the host has the environment variables HTTP_PROXY and no_proxy
-defined, both will be propagated to fakemachine respecting the case.
+defined, both will be propagated to the build environment respecting the
+case.
 .PP
 The command line options \f[CR]\-\-environ\-var\f[R] and \f[CR]\-e\f[R]
 can be used to specify, overwrite and unset environment variables for
-fakemachine with the syntax:
+the build environment with the syntax:
 .IP
 .EX
 debos \-e ENVIRONVAR:VALUE ...
 .EE
 .PP
 To unset an environment variable, or in other words, to prevent an
-environment variable being propagated to fakemachine, use the same
-syntax without a value.
+environment variable being propagated to the build environment, use the
+same syntax without a value.
 debos accepts multiple \-e simultaneously.
 .SH PROXY CONFIGURATION
 While the proxy related environment variables are exported from the host

--- a/doc/man/debos.1
+++ b/doc/man/debos.1
@@ -269,7 +269,7 @@ debos\-recipes
 \&.
 .SH ENVIRONMENT VARIABLES
 debos reads a predefined list of environment variables from the host and
-propagates them to the fakemachine build environment.
+propagates them to the build environment.
 The set of environment variables is defined by \f[CR]environ_vars\f[R]
 in \f[CR]cmd/debos/debos.go\f[R].
 Currently the list of environment variables includes the proxy
@@ -277,7 +277,7 @@ environment variables documented at:
 .PP
 https://wiki.archlinux.org/index.php/proxy_settings
 .PP
-The list of environment variables currently exported to fakemachine is:
+The list of environment variables currently exported is:
 .IP
 .EX
 http_proxy, https_proxy, ftp_proxy, rsync_proxy, all_proxy, no_proxy
@@ -285,21 +285,22 @@ http_proxy, https_proxy, ftp_proxy, rsync_proxy, all_proxy, no_proxy
 .PP
 While the elements of \f[CR]environ_vars\f[R] are in lower case, for
 each element both lower and upper case variants are probed on the host
-and if found propagated to fakemachine.
+and if found are propagated to the build environment.
 So if the host has the environment variables HTTP_PROXY and no_proxy
-defined, both will be propagated to fakemachine respecting the case.
+defined, both will be propagated to the build environment respecting the
+case.
 .PP
 The command line options \f[CR]\-\-environ\-var\f[R] and \f[CR]\-e\f[R]
 can be used to specify, overwrite and unset environment variables for
-fakemachine with the syntax:
+the build environment with the syntax:
 .IP
 .EX
 debos \-e ENVIRONVAR:VALUE ...
 .EE
 .PP
 To unset an environment variable, or in other words, to prevent an
-environment variable being propagated to fakemachine, use the same
-syntax without a value.
+environment variable being propagated to the build environment, use the
+same syntax without a value.
 debos accepts multiple \-e simultaneously.
 .SH PROXY CONFIGURATION
 While the proxy related environment variables are exported from the host

--- a/doc/man/debos.md
+++ b/doc/man/debos.md
@@ -179,14 +179,13 @@ recipes. Additional more detailed example recipes are stored under [debos-recipe
 # ENVIRONMENT VARIABLES
 
 debos reads a predefined list of environment variables from the host and
-propagates them to the fakemachine build environment. The set of
-environment variables is defined by `environ_vars` in
-`cmd/debos/debos.go`. Currently the list of environment variables includes
-the proxy environment variables documented at:
+propagates them to the build environment. The set of environment variables
+is defined by `environ_vars` in `cmd/debos/debos.go`. Currently the list of
+environment variables includes the proxy environment variables documented at:
 
 https://wiki.archlinux.org/index.php/proxy_settings
 
-The list of environment variables currently exported to fakemachine is:
+The list of environment variables currently exported is:
 
 ```
 http_proxy, https_proxy, ftp_proxy, rsync_proxy, all_proxy, no_proxy
@@ -194,20 +193,21 @@ http_proxy, https_proxy, ftp_proxy, rsync_proxy, all_proxy, no_proxy
 
 While the elements of `environ_vars` are in lower case, for each element
 both lower and upper case variants are probed on the host and if found
-propagated to fakemachine. So if the host has the environment variables
-HTTP_PROXY and no_proxy defined, both will be propagated to fakemachine
-respecting the case.
+are propagated to the build environment. So if the host has the environment
+variables HTTP_PROXY and no_proxy defined, both will be propagated to the build
+environment respecting the case.
 
 The command line options `--environ-var` and `-e` can be used to specify,
-overwrite and unset environment variables for fakemachine with the syntax:
+overwrite and unset environment variables for the build environment with the
+syntax:
 
 ```bash
 debos -e ENVIRONVAR:VALUE ...
 ```
 
 To unset an environment variable, or in other words, to prevent an
-environment variable being propagated to fakemachine, use the same syntax
-without a value. debos accepts multiple -e simultaneously.
+environment variable being propagated to the build environment, use the same
+syntax without a value. debos accepts multiple -e simultaneously.
 
 # PROXY CONFIGURATION
 

--- a/doc/man/debos.md
+++ b/doc/man/debos.md
@@ -223,14 +223,13 @@ recipes. Additional more detailed example recipes are stored under [debos-recipe
 # ENVIRONMENT VARIABLES
 
 debos reads a predefined list of environment variables from the host and
-propagates them to the fakemachine build environment. The set of
-environment variables is defined by `environ_vars` in
-`cmd/debos/debos.go`. Currently the list of environment variables includes
-the proxy environment variables documented at:
+propagates them to the build environment. The set of environment variables
+is defined by `environ_vars` in `cmd/debos/debos.go`. Currently the list of
+environment variables includes the proxy environment variables documented at:
 
 https://wiki.archlinux.org/index.php/proxy_settings
 
-The list of environment variables currently exported to fakemachine is:
+The list of environment variables currently exported is:
 
 ```
 http_proxy, https_proxy, ftp_proxy, rsync_proxy, all_proxy, no_proxy
@@ -238,20 +237,21 @@ http_proxy, https_proxy, ftp_proxy, rsync_proxy, all_proxy, no_proxy
 
 While the elements of `environ_vars` are in lower case, for each element
 both lower and upper case variants are probed on the host and if found
-propagated to fakemachine. So if the host has the environment variables
-HTTP_PROXY and no_proxy defined, both will be propagated to fakemachine
-respecting the case.
+are propagated to the build environment. So if the host has the environment
+variables HTTP_PROXY and no_proxy defined, both will be propagated to the build
+environment respecting the case.
 
 The command line options `--environ-var` and `-e` can be used to specify,
-overwrite and unset environment variables for fakemachine with the syntax:
+overwrite and unset environment variables for the build environment with the
+syntax:
 
 ```bash
 debos -e ENVIRONVAR:VALUE ...
 ```
 
 To unset an environment variable, or in other words, to prevent an
-environment variable being propagated to fakemachine, use the same syntax
-without a value. debos accepts multiple -e simultaneously.
+environment variable being propagated to the build environment, use the same
+syntax without a value. debos accepts multiple -e simultaneously.
 
 # PROXY CONFIGURATION
 


### PR DESCRIPTION
Introduce NewCommandForContext to mirror NewChrootCommandForContext, populating EnvironVars for commands that run outside the chroot, including running debos with --disable-fakemachine and postprocess run actions.

Fixes: #254