### PR TITLE
docs: clarify -t flag variables use dot notation not $var syntax

### DIFF
--- a/actions/recipe.go
+++ b/actions/recipe.go
@@ -30,6 +30,18 @@ Comments are allowed and should be prefixed with '#' symbol.
 	    # Use value of variable 'Var' defined above
 	    property2: {{$Var}}
 
+Variables passed via the `-t NAME:VALUE` command line argument are available as
+a field on the template data object, not as local variables:
+
+	# Use a variable passed with `-t Var:Value`
+	property: {{ .Var }}
+
+This is distinct from local variables declared inside the recipe itself,
+which use the `$Var` syntax:
+
+	{{- $Var := "Value" -}}
+	property: {{ $Var }}
+
 The following custom template functions are available:
 
 - sector: Returns the argument with 's' suffix for raw action` (Deprecated)


### PR DESCRIPTION
Variables injected to recipes via `-t NAME:VALUE` are accessed as `.NAME` in recipe templates rather than `$NAME`. Add an explicit example to the recipe package doc to distinguish `-t` flag variables (`.NAME`) from recipe-local variables (`$NAME`).

Update the help text for the `-t` flag and also update the README and man pages to match the new option.

Fixes: #356