### PR TITLE
Improve debos command-line option defaults and help text

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,20 +10,21 @@ debos [--help]
 Application Options:
 
 ```
-  -b, --fakemachine-backend=   Fakemachine backend to use (default: auto)
-      --artifactdir=           Directory for packed archives and ostree repositories (default: current directory)
-  -t, --template-var=          Template variables (use -t VARIABLE:VALUE syntax)
-      --debug-shell            Fall into interactive shell on error
-  -s, --shell=                 Redefine interactive shell binary (default: bash) (default: /bin/bash)
-      --scratchsize=           Size of disk backed scratch space
-  -c, --cpus=                  Number of CPUs to use for build VM (default: 2)
-  -m, --memory=                Amount of memory for build VM (default: 2048MB)
-      --show-boot              Show boot/console messages from the fake machine
-  -e, --environ-var=           Environment variables (use -e VARIABLE:VALUE syntax)
-  -v, --verbose                Verbose output
-      --print-recipe           Print final recipe
-      --dry-run                Compose final recipe to build but without any real work started
-      --disable-fakemachine    Do not use fakemachine.
+  -b, --fakemachine-backend=[auto|kvm|qemu] Fakemachine backend to use (default: auto)
+      --artifactdir=                        Directory for packed archives and ostree repositories (default: current directory)
+  -t, --template-var=                       Template variables (use -t VARIABLE:VALUE syntax)
+      --debug-shell                         Fall into interactive shell on error
+  -s, --shell=                              Redefine interactive shell binary (default: bash) (default: /bin/bash)
+      --scratchsize=                        Size of disk-backed scratch space (parsed with human-readable suffix; assumed bytes if no suffix)
+  -c, --cpus=                               Number of CPUs to use for build VM (default: 2)
+  -m, --memory=                             Amount of memory for build VM (parsed with human-readable suffix; assumed bytes if no suffix) (default: 2Gb)
+      --show-boot                           Show boot/console messages from the fakemachine
+  -e, --environ-var=                        Environment variables (use -e VARIABLE:VALUE syntax)
+  -v, --verbose                             Verbose output
+      --print-recipe                        Print the final recipe
+      --dry-run                             Check the final recipe and verify all actions without executing them
+      --disable-fakemachine                 Do not use fakemachine
+      --version                             Print debos version
 ```
 
 ## Description

--- a/cmd/debos/debos.go
+++ b/cmd/debos/debos.go
@@ -114,7 +114,7 @@ func main() {
 		ShowBoot           bool              `long:"show-boot" description:"Show boot/console messages from the fakemachine"`
 		EnvironVars        map[string]string `short:"e" long:"environ-var" description:"Environment variables (use -e VARIABLE:VALUE syntax)"`
 		Verbose            bool              `short:"v" long:"verbose" description:"Verbose output"`
-		PrintRecipe        bool              `long:"print-recipe" description:"Print final recipe"`
+		PrintRecipe        bool              `long:"print-recipe" description:"Print the final recipe"`
 		DryRun             bool              `long:"dry-run" description:"Compose final recipe to build but without any real work started"`
 		DisableFakeMachine bool              `long:"disable-fakemachine" description:"Do not use fakemachine."`
 		Version            bool              `long:"version" description:"Print debos version"`

--- a/cmd/debos/debos.go
+++ b/cmd/debos/debos.go
@@ -110,7 +110,7 @@ func main() {
 		Shell              string            `short:"s" long:"shell" description:"Redefine interactive shell binary (default: bash)" optionsl:"" default:"/bin/bash"`
 		ScratchSize        string            `long:"scratchsize" description:"Size of disk-backed scratch space (parsed with human-readable suffix; assumed bytes if no suffix)"`
 		CPUs               int               `short:"c" long:"cpus" description:"Number of CPUs to use for build VM" default:"2"`
-		Memory             string            `short:"m" long:"memory" description:"Amount of memory for build VM (parsed with human-readable suffix; assumed bytes if no suffix. default: 2Gb)"`
+		Memory             string            `short:"m" long:"memory" description:"Amount of memory for build VM (parsed with human-readable suffix; assumed bytes if no suffix)" default:"2Gb"`
 		ShowBoot           bool              `long:"show-boot" description:"Show boot/console messages from the fake machine"`
 		EnvironVars        map[string]string `short:"e" long:"environ-var" description:"Environment variables (use -e VARIABLE:VALUE syntax)"`
 		Verbose            bool              `short:"v" long:"verbose" description:"Verbose output"`
@@ -306,10 +306,6 @@ func main() {
 	if runInFakeMachine {
 		var args []string
 
-		if options.Memory == "" {
-			// Set default memory size for fakemachine
-			options.Memory = "2Gb"
-		}
 		memsize, err := units.RAMInBytes(options.Memory)
 		if err != nil {
 			log.Printf("Couldn't parse memory size: %v\n", err)

--- a/cmd/debos/debos.go
+++ b/cmd/debos/debos.go
@@ -115,7 +115,7 @@ func main() {
 		EnvironVars        map[string]string `short:"e" long:"environ-var" description:"Environment variables (use -e VARIABLE:VALUE syntax)"`
 		Verbose            bool              `short:"v" long:"verbose" description:"Verbose output"`
 		PrintRecipe        bool              `long:"print-recipe" description:"Print the final recipe"`
-		DryRun             bool              `long:"dry-run" description:"Compose final recipe to build but without any real work started"`
+		DryRun             bool              `long:"dry-run" description:"Check the final recipe and verify all actions without executing them"`
 		DisableFakeMachine bool              `long:"disable-fakemachine" description:"Do not use fakemachine."`
 		Version            bool              `long:"version" description:"Print debos version"`
 	}

--- a/cmd/debos/debos.go
+++ b/cmd/debos/debos.go
@@ -116,7 +116,7 @@ func main() {
 		Verbose            bool              `short:"v" long:"verbose" description:"Verbose output"`
 		PrintRecipe        bool              `long:"print-recipe" description:"Print the final recipe"`
 		DryRun             bool              `long:"dry-run" description:"Check the final recipe and verify all actions without executing them"`
-		DisableFakeMachine bool              `long:"disable-fakemachine" description:"Do not use fakemachine."`
+		DisableFakeMachine bool              `long:"disable-fakemachine" description:"Do not use fakemachine"`
 		Version            bool              `long:"version" description:"Print debos version"`
 	}
 

--- a/cmd/debos/debos.go
+++ b/cmd/debos/debos.go
@@ -111,7 +111,7 @@ func main() {
 		ScratchSize        string            `long:"scratchsize" description:"Size of disk-backed scratch space (parsed with human-readable suffix; assumed bytes if no suffix)"`
 		CPUs               int               `short:"c" long:"cpus" description:"Number of CPUs to use for build VM" default:"2"`
 		Memory             string            `short:"m" long:"memory" description:"Amount of memory for build VM (parsed with human-readable suffix; assumed bytes if no suffix)" default:"2Gb"`
-		ShowBoot           bool              `long:"show-boot" description:"Show boot/console messages from the fake machine"`
+		ShowBoot           bool              `long:"show-boot" description:"Show boot/console messages from the fakemachine"`
 		EnvironVars        map[string]string `short:"e" long:"environ-var" description:"Environment variables (use -e VARIABLE:VALUE syntax)"`
 		Verbose            bool              `short:"v" long:"verbose" description:"Verbose output"`
 		PrintRecipe        bool              `long:"print-recipe" description:"Print final recipe"`

--- a/cmd/debos/debos.go
+++ b/cmd/debos/debos.go
@@ -109,7 +109,7 @@ func main() {
 		DebugShell         bool              `long:"debug-shell" description:"Fall into interactive shell on error"`
 		Shell              string            `short:"s" long:"shell" description:"Redefine interactive shell binary (default: bash)" optionsl:"" default:"/bin/bash"`
 		ScratchSize        string            `long:"scratchsize" description:"Size of disk-backed scratch space (parsed with human-readable suffix; assumed bytes if no suffix)"`
-		CPUs               int               `short:"c" long:"cpus" description:"Number of CPUs to use for build VM (default: 2)"`
+		CPUs               int               `short:"c" long:"cpus" description:"Number of CPUs to use for build VM" default:"2"`
 		Memory             string            `short:"m" long:"memory" description:"Amount of memory for build VM (parsed with human-readable suffix; assumed bytes if no suffix. default: 2Gb)"`
 		ShowBoot           bool              `long:"show-boot" description:"Show boot/console messages from the fake machine"`
 		EnvironVars        map[string]string `short:"e" long:"environ-var" description:"Environment variables (use -e VARIABLE:VALUE syntax)"`
@@ -323,10 +323,6 @@ func main() {
 		}
 		m.SetMemory(memsizeMB)
 
-		if options.CPUs == 0 {
-			// Set default CPU count for fakemachine
-			options.CPUs = 2
-		}
 		m.SetNumCPUs(options.CPUs)
 		m.SetSectorSize(r.SectorSize)
 

--- a/doc/man/debos.1
+++ b/doc/man/debos.1
@@ -13,20 +13,21 @@ debos [\-\-help]
 Application Options:
 .IP
 .EX
-  \-b, \-\-fakemachine\-backend=   Fakemachine backend to use (default: auto)
-      \-\-artifactdir=           Directory for packed archives and ostree repositories (default: current directory)
-  \-t, \-\-template\-var=          Template variables (use \-t VARIABLE:VALUE syntax)
-      \-\-debug\-shell            Fall into interactive shell on error
-  \-s, \-\-shell=                 Redefine interactive shell binary (default: bash) (default: /bin/bash)
-      \-\-scratchsize=           Size of disk backed scratch space
-  \-c, \-\-cpus=                  Number of CPUs to use for build VM (default: 2)
-  \-m, \-\-memory=                Amount of memory for build VM (default: 2048MB)
-      \-\-show\-boot              Show boot/console messages from the fake machine
-  \-e, \-\-environ\-var=           Environment variables (use \-e VARIABLE:VALUE syntax)
-  \-v, \-\-verbose                Verbose output
-      \-\-print\-recipe           Print final recipe
-      \-\-dry\-run                Compose final recipe to build but without any real work started
-      \-\-disable\-fakemachine    Do not use fakemachine.
+  \-b, \-\-fakemachine\-backend=[auto|kvm|qemu] Fakemachine backend to use (default: auto)
+      \-\-artifactdir=                        Directory for packed archives and ostree repositories (default: current directory)
+  \-t, \-\-template\-var=                       Template variables (use \-t VARIABLE:VALUE syntax)
+      \-\-debug\-shell                         Fall into interactive shell on error
+  \-s, \-\-shell=                              Redefine interactive shell binary (default: bash) (default: /bin/bash)
+      \-\-scratchsize=                        Size of disk\-backed scratch space (parsed with human\-readable suffix; assumed bytes if no suffix)
+  \-c, \-\-cpus=                               Number of CPUs to use for build VM (default: 2)
+  \-m, \-\-memory=                             Amount of memory for build VM (parsed with human\-readable suffix; assumed bytes if no suffix) (default: 2Gb)
+      \-\-show\-boot                           Show boot/console messages from the fakemachine
+  \-e, \-\-environ\-var=                        Environment variables (use \-e VARIABLE:VALUE syntax)
+  \-v, \-\-verbose                             Verbose output
+      \-\-print\-recipe                        Print the final recipe
+      \-\-dry\-run                             Check the final recipe and verify all actions without executing them
+      \-\-disable\-fakemachine                 Do not use fakemachine
+      \-\-version                             Print debos version
 .EE
 .SH DESCRIPTION
 debos is a tool to make the creation of various Debian\-based OS images

--- a/doc/man/debos.md
+++ b/doc/man/debos.md
@@ -15,20 +15,21 @@ debos [--help]
 Application Options:
 
 ```
-  -b, --fakemachine-backend=   Fakemachine backend to use (default: auto)
-      --artifactdir=           Directory for packed archives and ostree repositories (default: current directory)
-  -t, --template-var=          Template variables (use -t VARIABLE:VALUE syntax)
-      --debug-shell            Fall into interactive shell on error
-  -s, --shell=                 Redefine interactive shell binary (default: bash) (default: /bin/bash)
-      --scratchsize=           Size of disk backed scratch space
-  -c, --cpus=                  Number of CPUs to use for build VM (default: 2)
-  -m, --memory=                Amount of memory for build VM (default: 2048MB)
-      --show-boot              Show boot/console messages from the fake machine
-  -e, --environ-var=           Environment variables (use -e VARIABLE:VALUE syntax)
-  -v, --verbose                Verbose output
-      --print-recipe           Print final recipe
-      --dry-run                Compose final recipe to build but without any real work started
-      --disable-fakemachine    Do not use fakemachine.
+  -b, --fakemachine-backend=[auto|kvm|qemu] Fakemachine backend to use (default: auto)
+      --artifactdir=                        Directory for packed archives and ostree repositories (default: current directory)
+  -t, --template-var=                       Template variables (use -t VARIABLE:VALUE syntax)
+      --debug-shell                         Fall into interactive shell on error
+  -s, --shell=                              Redefine interactive shell binary (default: bash) (default: /bin/bash)
+      --scratchsize=                        Size of disk-backed scratch space (parsed with human-readable suffix; assumed bytes if no suffix)
+  -c, --cpus=                               Number of CPUs to use for build VM (default: 2)
+  -m, --memory=                             Amount of memory for build VM (parsed with human-readable suffix; assumed bytes if no suffix) (default: 2Gb)
+      --show-boot                           Show boot/console messages from the fakemachine
+  -e, --environ-var=                        Environment variables (use -e VARIABLE:VALUE syntax)
+  -v, --verbose                             Verbose output
+      --print-recipe                        Print the final recipe
+      --dry-run                             Check the final recipe and verify all actions without executing them
+      --disable-fakemachine                 Do not use fakemachine
+      --version                             Print debos version
 ```
 
 # DESCRIPTION


### PR DESCRIPTION
This PR tidies up the debos command-line option definitions and help text.

The main functional cleanup is moving the default values for --cpus and --memory into the option definitions themselves, instead of applying those defaults later in the fakemachine setup path. While here, I fixed some text in the other help options.