### PR TITLE
run: Catch undefined variables

### DIFF
--- a/actions/run_action.go
+++ b/actions/run_action.go
@@ -161,7 +161,7 @@ func (run *RunAction) doRun(context debos.Context) error {
 	}
 
 	// Command/script with options passed as single string
-	cmdline = append([]string{"sh", "-e", "-c"}, cmdline...)
+	cmdline = append([]string{"sh", "-e", "-u", "-c"}, cmdline...)
 
 	if !run.Chroot {
 		cmd.AddEnvKey("RECIPEDIR", context.RecipeDir)


### PR DESCRIPTION
Non-trivial run commands can contain variables,
make sure to catch undefined ones.