### PR TITLE
actions/image-partition: validate parted units for start/end

### DIFF
--- a/actions/image_partition_action.go
+++ b/actions/image_partition_action.go
@@ -23,7 +23,7 @@ Mandatory properties:
 
 - imagename -- the name of the image file, relative to the artifact directory.
 
-- imagesize -- generated image size in human-readable form, examples: 100MB, 1GB, etc.
+- imagesize -- generated image size in human-readable form, examples: 100MiB, 1GiB, etc.
 
 - partitiontype -- partition table type. Currently only 'gpt' and 'msdos'
 partition tables are supported.
@@ -75,8 +75,13 @@ unique.
 
 - end -- offset from beginning of the disk there the partition ends.
 
-For 'start' and 'end' properties offset can be written in human readable
-form -- '32MB', '1GB' or as disk percentage -- '100%'.
+For 'start' and 'end' properties the offset must use a unit understood by
+parted(8): 's' (sectors), 'B' (bytes), 'kB', 'MB', 'GB', 'TB' (decimal,
+powers of 1000), 'KiB', 'MiB', 'GiB', 'TiB' (binary, powers of 1024),
+'cyl', 'chs' or '%' (percentage of the device). The value is passed to
+parted as-is; debos only validates the unit and prints a warning when a
+decimal (non-power-of-two) unit is used, since the binary equivalents
+align more naturally on disk sector boundaries.
 
 Optional properties:
 
@@ -157,7 +162,7 @@ Defaults to false.
 	# Layout example for Raspberry PI 3:
 	- action: image-partition
 	  imagename: "debian-rpi3.img"
-	  imagesize: 1GB
+	  imagesize: 1GiB
 	  partitiontype: msdos
 	  mountpoints:
 	    - mountpoint: /
@@ -169,10 +174,10 @@ Defaults to false.
 	    - name: firmware
 	      fs: vfat
 	      start: 0%
-	      end: 64MB
+	      end: 64MiB
 	    - name: root
 	      fs: ext4
-	      start: 64MB
+	      start: 64MiB
 	      end: 100%
 	      flags: [ boot ]
 */
@@ -769,6 +774,94 @@ func (i ImagePartitionAction) PostMachineCleanup(context *debos.Context) error {
 	return nil
 }
 
+var (
+	// Decimal magnitude suffix: k/M/G/T/P, optionally followed by 'B'
+	// (e.g. "M", "MB", "mb"). Case-insensitive.
+	decimalUnitRe = regexp.MustCompile(`(?i)^[kmgtp]b?$`)
+	// Binary (IEC) magnitude suffix: k/M/G/T/P followed by 'iB'
+	// (e.g. "MiB", "mib"). Case-insensitive.
+	binaryUnitRe = regexp.MustCompile(`(?i)^[kmgtp]ib$`)
+)
+
+// validatePartedUnit checks that value's unit suffix is one parted(8)
+// understands: 's' (sectors), 'B' (bytes), 'kB'/'MB'/'GB'/'TB' (decimal,
+// powers of 1000), 'KiB'/'MiB'/'GiB'/'TiB' (binary, powers of 1024),
+// 'cyl', 'chs' and '%' (percentage of the device). An empty unit is parted's
+// default of sectors. parted is case-insensitive and accepts the magnitude
+// letter without the trailing 'B', so '256M' is treated as '256MB'.
+// Decimal forms are accepted but trigger a warning recommending the binary
+// equivalents, since they rarely align cleanly on sector boundaries.
+func validatePartedUnit(field, value string) error {
+	v := strings.TrimSpace(value)
+	if v == "" {
+		return fmt.Errorf("%s: empty value", field)
+	}
+
+	// Split numeric prefix from unit suffix.
+	i := 0
+	for i < len(v) {
+		c := v[i]
+		if (c >= '0' && c <= '9') || c == '.' || c == '-' || c == '+' {
+			i++
+			continue
+		}
+		break
+	}
+	number, unit := v[:i], v[i:]
+
+	if number == "" {
+		return fmt.Errorf("%s: value %q has no numeric portion", field, value)
+	}
+	if _, err := strconv.ParseFloat(number, 64); err != nil {
+		return fmt.Errorf("%s: value %q is not a number", field, value)
+	}
+
+	switch strings.ToLower(unit) {
+	case "", "s", "b", "%", "cyl", "chs":
+		return nil
+	}
+
+	if binaryUnitRe.MatchString(unit) {
+		return nil
+	}
+	if decimalUnitRe.MatchString(unit) {
+		log.Printf("Warning: %s value %q uses non-power-of-two unit %q; "+
+			"prefer KiB, MiB, GiB or TiB to align on power-of-two boundaries",
+			field, value, unit)
+		return nil
+	}
+
+	return fmt.Errorf("%s: value %q uses unsupported unit %q "+
+		"(parted accepts: s, B, kB, MB, GB, TB, KiB, MiB, GiB, TiB, cyl, chs, %%)",
+		field, value, unit)
+}
+
+// parseHumanSize parses a size string with the go-units package and returns
+// the byte count. Binary (IEC) suffixes go through units.RAMInBytes so they
+// resolve as powers of 1024; everything else goes through units.FromHumanSize
+// (powers of 1000). Caller is expected to validate the unit shape first
+// (e.g. via validatePartedUnit) so this only handles the numeric conversion.
+func parseHumanSize(field, value string) (int64, error) {
+	v := strings.TrimSpace(value)
+	if v == "" {
+		return 0, fmt.Errorf("%s: empty value", field)
+	}
+
+	if regexp.MustCompile(`(?i)^[0-9.]+\s*[kmgtp]ib$`).MatchString(v) {
+		b, err := units.RAMInBytes(v)
+		if err != nil {
+			return 0, fmt.Errorf("invalid %s %q: %w", field, value, err)
+		}
+		return b, nil
+	}
+
+	b, err := units.FromHumanSize(v)
+	if err != nil {
+		return 0, fmt.Errorf("invalid %s %q: %w", field, value, err)
+	}
+	return b, nil
+}
+
 func (i *ImagePartitionAction) Verify(_ *debos.Context) error {
 	if i.PartitionType == "msdos" {
 		for idx := range i.Partitions {
@@ -805,10 +898,8 @@ func (i *ImagePartitionAction) Verify(_ *debos.Context) error {
 		if i.PartitionType != "gpt" {
 			return fmt.Errorf("gpt_gap property could be used only with 'gpt' label")
 		}
-		// Just check if it contains correct value
-		_, err := units.FromHumanSize(i.GptGap)
-		if err != nil {
-			return fmt.Errorf("failed to parse image size: %s", i.GptGap)
+		if err := validatePartedUnit("gpt_gap", i.GptGap); err != nil {
+			return err
 		}
 	}
 
@@ -906,6 +997,13 @@ func (i *ImagePartitionAction) Verify(_ *debos.Context) error {
 			return fmt.Errorf("partition %s missing end", p.Name)
 		}
 
+		if err := validatePartedUnit(fmt.Sprintf("partition %s start", p.Name), p.Start); err != nil {
+			return err
+		}
+		if err := validatePartedUnit(fmt.Sprintf("partition %s end", p.Name), p.End); err != nil {
+			return err
+		}
+
 		if p.FS == "" {
 			return fmt.Errorf("partition %s missing fs type", p.Name)
 		}
@@ -971,21 +1069,14 @@ func (i *ImagePartitionAction) Verify(_ *debos.Context) error {
 		}
 	}
 
-	// Calculate the size based on the unit (binary or decimal)
-	// binary units are multiples of 1024 - KiB, MiB, GiB, TiB, PiB
-	// decimal units are multiples of 1000 - KB, MB, GB, TB, PB
-	var getSizeValueFunc func(size string) (int64, error)
-	if regexp.MustCompile(`^[0-9.]+[kmgtp]ib+$`).MatchString(strings.ToLower(i.ImageSize)) {
-		getSizeValueFunc = units.RAMInBytes
-	} else {
-		getSizeValueFunc = units.FromHumanSize
+	if err := validatePartedUnit("imagesize", i.ImageSize); err != nil {
+		return err
 	}
-
-	size, err := getSizeValueFunc(i.ImageSize)
+	size, err := parseHumanSize("imagesize", i.ImageSize)
 	if err != nil {
-		return fmt.Errorf("failed to parse image size: %s", i.ImageSize)
+		return err
 	}
-
 	i.size = size
+
 	return nil
 }

--- a/tests/exit_test/missing_mountpoint.yaml
+++ b/tests/exit_test/missing_mountpoint.yaml
@@ -4,7 +4,7 @@ actions:
   - action: image-partition
     description: Partition the image
     imagename: test.img
-    imagesize: 1G
+    imagesize: 1GiB
     partitiontype: msdos
     diskid: deadbeef
     mountpoints:
@@ -14,4 +14,4 @@ actions:
       - name: system
         fs: ext4
         start: 0%
-        end: 1G
+        end: 1GiG

--- a/tests/exit_test/missing_partition.yaml
+++ b/tests/exit_test/missing_partition.yaml
@@ -4,7 +4,7 @@ actions:
   - action: image-partition
     description: Partition the image
     imagename: test.img
-    imagesize: 1G
+    imagesize: 1GiB
     partitiontype: msdos
     diskid: deadbeef
     mountpoints:
@@ -14,4 +14,4 @@ actions:
       - name: system
         fs: ext4
         start: 0%
-        end: 1G
+        end: 1GiB

--- a/tests/msdos/test.yaml
+++ b/tests/msdos/test.yaml
@@ -4,7 +4,7 @@ actions:
   - action: image-partition
     description: Partition the image
     imagename: test.img
-    imagesize: 8G
+    imagesize: 8GiB
     partitiontype: msdos
     diskid: deadbeef
     mountpoints:
@@ -14,35 +14,35 @@ actions:
       - name: boot
         fs: ext2
         start: 0%
-        end: 256M
+        end: 256MiB
       - name: system
         fs: ext4
-        start: 256m
-        end: 2G
+        start: 256MiB
+        end: 2GiB
       - name: data0
         fs: ext4
-        start: 2G
-        end: 3G
+        start: 2GiB
+        end: 3GiB
       - name: data1
         fs: ext4
-        start: 3G
-        end: 4G
+        start: 3GiB
+        end: 4GiB
       - name: data2
         fs: ext4
-        start: 4G
-        end: 5G
+        start: 4GiB
+        end: 5GiB
       - name: data3
         fs: ext4
-        start: 5G
-        end: 6G
+        start: 5GiB
+        end: 6GiB
       - name: data4
         fs: ext4
-        start: 6G
-        end: 7G
+        start: 6GiB
+        end: 7GiB
       - name: data5
         fs: ext4
-        start: 7G
-        end: 8G
+        start: 7GiB
+        end: 8GiB
 
   - action: run
     chroot: false

--- a/tests/partitioning-sector-size/test.yaml
+++ b/tests/partitioning-sector-size/test.yaml
@@ -5,12 +5,12 @@ actions:
   - action: image-partition
     description: Create a {{ $sectorsize }} sector size image
     imagename: test.img
-    imagesize: 10M
+    imagesize: 10MiB
     partitiontype: gpt
     partitions:
       - name: system
         fs: ext4
-        start: 2m
+        start: 2MiB
         end: 100%
 #
 # Would more elegant to check the sector size with

--- a/tests/partitioning/test.yaml
+++ b/tests/partitioning/test.yaml
@@ -4,7 +4,7 @@ actions:
   - action: image-partition
     description: Partition the image
     imagename: test.img
-    imagesize: 8G
+    imagesize: 8GiB
     partitiontype: gpt
     diskid: 12345678-1234-1234-1234-123456789012
     mountpoints:
@@ -14,36 +14,36 @@ actions:
       - name: boot
         fs: ext2
         start: 0%
-        end: 256M
+        end: 256MiB
       - name: system
         fs: ext4
-        start: 256m
-        end: 2G
+        start: 256MiB
+        end: 2GiB
         partuuid: 87654321-1234-5678-9012-345678901234
       - name: data0
         fs: ext4
-        start: 2G
-        end: 3G
+        start: 2GiB
+        end: 3GiB
       - name: data1
         fs: ext4
-        start: 3G
-        end: 4G
+        start: 3GiB
+        end: 4GiB
       - name: data2
         fs: ext4
-        start: 4G
-        end: 5G
+        start: 4GiB
+        end: 5GiB
       - name: data3
         fs: ext4
-        start: 5G
-        end: 6G
+        start: 5GiB
+        end: 6GiB
       - name: data4
         fs: ext4
-        start: 6G
-        end: 7G
+        start: 6GiB
+        end: 7GiB
       - name: data5
         fs: ext4
-        start: 7G
-        end: 8G
+        start: 7GiB
+        end: 8GiB
 
   - action: run
     chroot: false

--- a/tests/raw/test.yaml
+++ b/tests/raw/test.yaml
@@ -6,7 +6,7 @@ actions:
   - action: image-partition
     description: Partition the image
     imagename: test.img
-    imagesize: 3G
+    imagesize: 3GiB
     partitiontype: msdos
 
   - action: overlay


### PR DESCRIPTION
The 'start' and 'end' YAML properties were forwarded to parted(8) verbatim, so typos or unsupported strings only surfaced as parted errors at run time. Validate them in Verify() against parted's documented unit set (s, B, kB, MB, GB, TB, KiB, MiB, GiB, TiB, cyl, chs, %) and reject anything else with an error that lists the canonical forms.

Decimal units (kB, MB, GB, TB) remain accepted for backward compatibility, but now emit a warning recommending the binary equivalents (KiB, MiB, GiB, TiB) so partitions align on power-of-two boundaries.

Match parted's documented casing exactly rather than folding case, so common typos like 'KB' or 'MIB' are reported instead of silently mapped.