### PR TITLE
Dockerfile: split recipe convenience tools into a separate layer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -94,45 +94,50 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends \
         apt-transport-https \
         binfmt-support \
-        bmap-tools \
         btrfs-progs \
         busybox \
-        bzip2 \
         ca-certificates \
         debian-ports-archive-keyring \
         debootstrap \
-        devscripts \
-        wget \
         mmdebstrap \
         dosfstools \
         e2fsprogs \
-        equivs \
         fdisk \
         f2fs-tools \
-        git \
-        gzip \
-        jq \
-        pigz \
         libostree-1-1 \
-        openssh-client \
         parted \
         pkg-config \
         qemu-user-binfmt \
         qemu-utils \
-        rsync \
         systemd \
         systemd-container \
         systemd-resolved \
-        u-boot-tools \
-        unzip \
         xfsprogs \
-        xz-utils \
-        zip \
-        zstd \
         makepkg \
         pacman-package-manager \
         arch-install-scripts \
         arch-test && \
+    rm -rf /var/lib/apt/lists/*
+
+# Convenience tools commonly used in recipes & test recipes
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        bmap-tools \
+        bzip2 \
+        devscripts \
+        equivs \
+        git \
+        gzip \
+        jq \
+        openssh-client \
+        pigz \
+        rsync \
+        u-boot-tools \
+        unzip \
+        wget \
+        xz-utils \
+        zip \
+        zstd && \
     rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder $GOPATH/bin/debos /usr/local/bin/debos

--- a/Dockerfile
+++ b/Dockerfile
@@ -99,12 +99,12 @@ RUN apt-get update && \
         ca-certificates \
         debian-ports-archive-keyring \
         debootstrap \
-        mmdebstrap \
         dosfstools \
         e2fsprogs \
-        fdisk \
         f2fs-tools \
+        fdisk \
         libostree-1-1 \
+        mmdebstrap \
         parted \
         pkg-config \
         qemu-user-binfmt \

--- a/Dockerfile
+++ b/Dockerfile
@@ -122,6 +122,7 @@ RUN apt-get update && \
 # Convenience tools commonly used in recipes & test recipes
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
+        android-sdk-libsparse-utils \
         bmaptool \
         bzip2 \
         devscripts \

--- a/Dockerfile
+++ b/Dockerfile
@@ -122,7 +122,7 @@ RUN apt-get update && \
 # Convenience tools commonly used in recipes & test recipes
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-        bmap-tools \
+        bmaptool \
         bzip2 \
         devscripts \
         equivs \

--- a/Dockerfile
+++ b/Dockerfile
@@ -92,7 +92,6 @@ LABEL org.label-schema.docker.cmd='docker run \
 # ca-certificates is required to validate HTTPS certificates when getting debootstrap release file
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-        apt-transport-https \
         binfmt-support \
         btrfs-progs \
         busybox \

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,22 +43,23 @@ COPY docker/get-archlinux-keyring.sh /
 RUN /get-archlinux-keyring.sh /arch-keyring
 
 ### second stage - runner ###
-FROM debian:trixie-slim AS runner-amd64
+# Install initramfs-tools and drop the kernel postinst hooks before installing
+# the kernel, so installing linux-image doesn't trigger an initramfs rebuild.
+FROM debian:trixie-slim AS runner-base
+ARG DEBIAN_FRONTEND
 RUN apt-get update && \
     apt-get install -y --no-install-recommends initramfs-tools && \
-    rm -rf /var/lib/apt/lists/*
-RUN rm /etc/kernel/postinst.d/*
+    rm -rf /var/lib/apt/lists/* && \
+    rm /etc/kernel/postinst.d/*
+
+FROM runner-base AS runner-amd64
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
         linux-image-amd64 \
         qemu-system-x86 && \
     rm -rf /var/lib/apt/lists/*
 
-FROM debian:trixie-slim AS runner-arm64
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends initramfs-tools && \
-    rm -rf /var/lib/apt/lists/*
-RUN rm /etc/kernel/postinst.d/*
+FROM runner-base AS runner-arm64
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
         linux-image-arm64 \


### PR DESCRIPTION
Reorganise the runtime package installation in the Dockerfile.

- Split the convenience tools that are only used from recipe scripts
  (bmaptool, git, rsync, u-boot-tools, wget and the compression
  utilities) out of the core debos runtime dependencies and into their
  own RUN/layer, making the core dependency list clearer.
- Rename the `bmap-tools` package to `bmaptool` (renamed in Debian).
- Add `android-sdk-libsparse-utils` for handling Android sparse images.

This introduces no functional changes - the same tools are still
available in the Docker container.