### PR TITLE
recipe: verify architecture is supported before parsing recipe

### DIFF
--- a/actions/recipe.go
+++ b/actions/recipe.go
@@ -108,10 +108,36 @@ import (
 	"log"
 	"path"
 	"reflect"
+	"slices"
 	"strconv"
 	"strings"
 	"text/template"
 )
+
+// supportedArchitectures lists the supperted target architectures.
+var supportedArchitectures = []string{
+	// Debian architectures
+	"amd64",
+	"arm64",
+	"armel",
+	"armhf",
+	"i386",
+	"mips64el",
+	"ppc64el",
+	"riscv64",
+	"s390x",
+	// Debian ports architectures
+	"alpha",
+	"hppa",
+	"loong64",
+	"m68k",
+	"mipsel",
+	"powerpc",
+	"ppc64",
+	"sh4",
+	"sparc64",
+	"x32",
+}
 
 /* the YamlAction just embed the Action interface and implements the
  * UnmarshalYAML function so it can select the concrete implementer of a
@@ -328,6 +354,11 @@ func (r *Recipe) Parse(file string, printRecipe bool, dump bool, templateVars ..
 
 	if len(r.Architecture) == 0 {
 		return fmt.Errorf("Recipe file must have 'architecture' property")
+	}
+
+	if !slices.Contains(supportedArchitectures, r.Architecture) {
+		return fmt.Errorf("unsupported architecture %q",
+			r.Architecture)
 	}
 
 	if len(r.Actions) == 0 {

--- a/actions/recipe_test.go
+++ b/actions/recipe_test.go
@@ -86,6 +86,15 @@ architecture: arm64
 `,
 			"Recipe file must have at least one action",
 		},
+		// Test for error with unsupported architecture
+		{`
+architecture: arm65
+
+actions:
+  - action: raw
+`,
+			"unsupported architecture \"arm65\"",
+		},
 		// Test of wrong syntax in Yaml
 		{`wrong`,
 			"[1:1] string was used where mapping is expected\n>  1 | wrong\n       ^\n",


### PR DESCRIPTION
The recipe architecture is currently passed straight through to the underlying tools (e.g. debootstrap) which can cause confusing errors like:

    Debootstrap | E: You must specify a suite and a target.

Validate the recipe's architecture against a set of known architectures and bail out early when an unknown architecture is requested.

Closes: #239