### PR TITLE
recipe: print expanded YAML when parsing fails

### DIFF
--- a/actions/recipe.go
+++ b/actions/recipe.go
@@ -319,6 +319,13 @@ func (r *Recipe) Parse(file string, printRecipe bool, dump bool, templateVars ..
 	}
 
 	if err := yaml.Unmarshal(data.Bytes(), r); err != nil {
+		// The line numbers in the error refer to the YAML after template
+		// expansion, which may not match the source file. Dump the expanded
+		// YAML to help locate the error, unless it has already been printed.
+		if !printRecipe {
+			log.Printf("Failed to parse recipe %q", file)
+			log.Printf("Dumping recipe after template expansion:\n%s", data.String())
+		}
 		return err
 	}
 


### PR DESCRIPTION
The YAML parser reports line numbers relative to the recipe after Golang template expansion. This does not necessarily match the line numbers in the source file which makes parse errors hard to locate.

Dump the expanded YAML after failing to parse the recipe such that the reported line numbers can be matched against actual content. Skip it when the recipe has already been printed via --print-recipe to avoid duplicate output.

Closes: #14