### PR TITLE
commands: opt out of nspawn socket address family filtering

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -10,6 +10,8 @@ import (
 	"os"
 	"os/exec"
 	"path"
+	"strings"
+	"sync"
 )
 
 type ChrootEnterMethod int
@@ -19,6 +21,26 @@ const (
 	ChrootMethodNspawn                          // use nspawn to create the chroot environment
 	ChrootMethodChroot                          // use chroot to create the chroot environment
 )
+
+// nspawnSupportsOption reports whether systemd-nspawn advertises the given option
+// in the --help output. The result is cached as the available options shouldn't
+// change.
+var nspawnOptions = struct {
+	once sync.Once
+	help string
+}{}
+
+func nspawnSupportsOption(option string) bool {
+	nspawnOptions.once.Do(func() {
+		out, err := exec.Command("systemd-nspawn", "--help").CombinedOutput()
+		if err != nil {
+			return
+		}
+		nspawnOptions.help = string(out)
+	})
+
+	return strings.Contains(nspawnOptions.help, option)
+}
 
 type Command struct {
 	Architecture string            // Architecture of the chroot, nil if same as host
@@ -233,6 +255,14 @@ func (cmd Command) Run(label string, cmdline ...string) error {
 		}
 		for _, b := range cmd.bindMounts {
 			options = append(options, "--bind", b)
+		}
+		// Future systemd-nspawn restricts the permitted socket address families
+		// by default. This would break commands relying on e.g. AF_NETLINK or
+		// AF_PACKET.
+		// In systemd >=261 it produces a warning. Opt out of the filtering
+		// explicitly when the option is supported.
+		if nspawnSupportsOption("--restrict-address-families=") {
+			options = append(options, "--restrict-address-families=")
 		}
 		options = append(options, "-D", cmd.Chroot)
 		options = append(options, cmdline...)


### PR DESCRIPTION
systemd-nspawn ?=261 emits a warning announcing that a future release will restrict the default set of permitted socket address families to AF_INET, AF_INET6 and AF_UNIX:

  Note that the default set of permitted socket address families will be
  restricted [...] Use --restrict-address-families= to configure the set of
  permitted socket address families, or set RestrictAddressFamilies= in a
  .nspawn file.

That future default would break commands run inside the chroot which rely on other families, such as AF_NETLINK (used by ip, udev, ...) or AF_PACKET.

Opt out of the filtering as recommended by passing an empty --restrict-address-families=. As this option is only available in recent systemd-nspawn, gate it on the option being advertised in --help so older versions continue to work.