### PR TITLE
fix: truncate existing /etc/fstab to prevent leftover data corruption

### DIFF
--- a/actions/filesystem_deploy_action.go
+++ b/actions/filesystem_deploy_action.go
@@ -18,7 +18,8 @@ image.
 Optional properties:
 
 - setup-fstab -- generate '/etc/fstab' file according to information provided
-by 'image-partition' action. By default is 'true'.
+by 'image-partition' action. If an existing '/etc/fstab' is present,
+it is overwritten. By default is 'true'.
 
 - setup-kernel-cmdline -- add location of root partition to '/etc/kernel/cmdline'
 file on target image. By default is 'true'.
@@ -66,7 +67,7 @@ func (fd *FilesystemDeployAction) setupFSTab(context *debos.Context) error {
 	}
 
 	fstab := path.Join(context.Rootdir, "etc/fstab")
-	f, err := os.OpenFile(fstab, os.O_RDWR|os.O_CREATE, 0755)
+	f, err := os.OpenFile(fstab, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0644)
 	if err != nil {
 		return fmt.Errorf("couldn't open /etc/fstab: %w", err)
 	}


### PR DESCRIPTION
## Problem

`setupFSTab()` opens an existing `/etc/fstab` with `O_RDWR|O_CREATE`, but does not truncate it before writing.

After the `debootstrap` stage, `/etc/fstab` already contains the default template:

```text
# UNCONFIGURED FSTAB FOR BASE SYSTEM
#
# <file system> <mount point>   <type>  <options>       <dump>  <pass>
```

The generated root filesystem entry is shorter than this template. As a result, the previous file contents are only partially overwritten, leaving trailing data from the original template.

For example, the resulting `fstab` becomes:

```text
UUID=12345678-1234-1234-1234-123456789abc / ext4 defaults,errors=remount-ro 0 1
options>       <dump>  <pass>
/swap none swap defaults 0 0
```

The leftover line is interpreted by `systemd-fstab-generator` as an invalid mount entry, producing warnings during boot.

This issue affects the generated Kali VM images (both stable and weekly), which are built using debos.

## Fix

Open `/etc/fstab` with `os.O_TRUNC` so any existing contents are removed before writing the new configuration.

Also change the file mode from `0755` to `0644`, which is the conventional permission for `/etc/fstab`.