### PR TITLE
ci: use rolling test-container names

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,7 +24,7 @@ jobs:
       run:
         shell: bash
     container:
-      image: ghcr.io/go-debos/test-containers/debian-stable:main
+      image: ghcr.io/go-debos/test-containers/debian-stable:wip-obbardc-small-cleanups
     steps:
     - name: Checkout code
       uses: actions/checkout@v7
@@ -78,7 +78,7 @@ jobs:
       run:
         shell: bash
     container:
-      image: ghcr.io/go-debos/test-containers/${{matrix.variant}}:main
+      image: ghcr.io/go-debos/test-containers/${{matrix.variant}}:wip-obbardc-small-cleanups
     steps:
     - name: Checkout code
       uses: actions/checkout@v7

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,7 +24,7 @@ jobs:
       run:
         shell: bash
     container:
-      image: ghcr.io/go-debos/test-containers/debian-trixie:main
+      image: ghcr.io/go-debos/test-containers/debian-stable:main
     steps:
     - name: Checkout code
       uses: actions/checkout@v7
@@ -69,9 +69,9 @@ jobs:
       matrix:
         variant:
           - arch
-          - debian-trixie
-          - debian-forky
-          - ubuntu-questing
+          - debian-stable
+          - debian-testing
+          - ubuntu-devel
           - fedora-latest
     runs-on: ubuntu-latest
     defaults:


### PR DESCRIPTION
The test-containers repository has switched from codename-specific image names to rolling aliases which track the current release, so the CI matrix no longer needs updating each time a distro release moves on.

Map the images accordingly:

  debian-trixie   -> debian-stable
  debian-forky    -> debian-testing
  ubuntu-questing -> ubuntu-devel

See https://github.com/go-debos/test-containers/pull/67